### PR TITLE
rulake-wasm@2.3.0-alpha.1 published + docs/userguide + accelerator-plane gist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install maturin + test deps
-        run: pip install maturin pytest numpy
       - name: Build + test
+        # `maturin develop` requires an active virtualenv (or CONDA_PREFIX,
+        # or a `.venv` it can find). The hosted runner's system Python
+        # has neither, so we create a `.venv` per job, install build +
+        # test deps into it, and let maturin install the wheel into it.
         working-directory: sdk/python
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          pip install maturin pytest numpy
           maturin develop --release
           pytest tests/ -v
 
@@ -92,7 +98,10 @@ jobs:
         working-directory: sdk/node
         run: |
           cargo build --release
-          cp target/release/libruvector_rulake_node.so rulake.linux-x64-gnu.node
+          # The crate is named `rulake-node` (sdk/node/Cargo.toml:1), so
+          # cargo emits `librulake_node.so` — not the older
+          # `libruvector_rulake_node.so` name from before the rename.
+          cp target/release/librulake_node.so rulake.linux-x64-gnu.node
       - name: Run smoke tests
         working-directory: sdk/node
         run: node --test __test__/smoke.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,17 @@ jobs:
       - name: Build mcp-rvdna binary
         working-directory: crates/mcp-rvdna
         run: cargo build --release --bin rvdna-mcp
+      - name: "Install + build sdk/node-wasm (rulake-wasm sibling, file: dep)"
+        # ui depends on rulake-wasm via `file:../sdk/node-wasm`. Vite picks
+        # the package.json `exports.".".browser` entry which is `./web/...`,
+        # but `web/` and `nodejs/` are gitignored (wasm-pack outputs).
+        # Build them now or Vite hard-fails with
+        # `[commonjs--resolver] Failed to resolve entry for package "rulake-wasm"`.
+        # Mirror what release-ui.yml does.
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install --locked wasm-pack || true
+          (cd sdk/node-wasm && unset RUSTFLAGS CARGO_BUILD_RUSTFLAGS && ./build.sh)
       - name: Install ui deps + build dist
         working-directory: ui
         run: |

--- a/docs/gists/README.md
+++ b/docs/gists/README.md
@@ -48,19 +48,23 @@ reader can land cold and follow along in the source.
 |---|---|---|---|
 | [ADR-156](../adrs/ADR-156-rulake-as-memory-substrate.md) | [memory-substrate-deep.md](memory-substrate-deep.md) | 3,174 | What makes ruLake a good memory layer for agentic systems; the witness-anchored cache as the trust anchor for cross-agent state. |
 
+### Accelerator-tier (where the inner loop runs)
+
+| ADR | Gist | Words | What it covers |
+|---|---|---|---|
+| [ADR-157](../adrs/ADR-157-optional-accelerator-plane.md) | [accelerator-plane-deep.md](accelerator-plane-deep.md) | 2,953 | The `VectorKernel` trait + dispatch policy; the two shipped kernels (AVX-512 host SIMD, wgpu portable GPU); determinism as a hard gate on witness-sealed paths. |
+
 ## ADRs without gists
 
-[ADR-157](../adrs/ADR-157-optional-accelerator-plane.md) (Optional
-Accelerator Plane / VectorKernel) and
 [ADR-158](../adrs/ADR-158-optional-rotation-and-qvcache-positioning.md)
-(Rotation Kind / QVCache positioning) are pure design contracts that
-explicitly note "no code changes accompany this ADR" as part of their
+(Rotation Kind / QVCache positioning) is a pure design contract that
+explicitly notes "no code changes accompany this ADR" as part of its
 decision. The ADR itself is the deliverable; a gist would just
-restate it. They'll get gists when they ship implementations.
+restate it. It will get one when it ships an implementation.
 
 ## Total
 
-**~31,000 words** across 10 gists, distilled from the ADRs + research
+**~34,000 words** across 11 gists, distilled from the ADRs + research
 notes + source code. Reading order if you're new to the project: start
 with [`standalone-repo-deep.md`](standalone-repo-deep.md) (what kind
 of project this is), then [`datalake-layer-deep.md`](datalake-layer-deep.md)
@@ -68,4 +72,5 @@ of project this is), then [`datalake-layer-deep.md`](datalake-layer-deep.md)
 agents call into it), then pick a substrate
 ([`rvdna-v2-deep.md`](rvdna-v2-deep.md) or
 [`ruqu-v2-deep.md`](ruqu-v2-deep.md)) for a deep dive on the
-trust-chain story.
+trust-chain story. For the runtime perf story, finish with
+[`accelerator-plane-deep.md`](accelerator-plane-deep.md).

--- a/docs/gists/accelerator-plane-deep.md
+++ b/docs/gists/accelerator-plane-deep.md
@@ -1,0 +1,136 @@
+# ruLake accelerator plane — A Deep Introduction
+
+## TL;DR
+
+The ruLake accelerator plane is the runtime + crate layout that lets the same `RuLake` binary route the popcount-scan + L2² rerank inner loop to a CPU-naive baseline, an AVX-512 host kernel, or a portable GPU kernel via wgpu — without forcing any of those backends into the core dependency graph and without ever letting a non-deterministic kernel feed a witness-sealed answer. The contract is the `VectorKernel` trait at `crates/core/src/kernel.rs` (id, caps, scan), the dispatch policy lives in `RuLake::pick_kernel` and consults `Consistency` + batch + dim, and conformance against `assert_kernel_conformant` is the only path past experimental. Two implementations ship today as standalone sibling crates — `crates/kernel-avx512/` (bit-equal, ~2.5% faster than CpuNaive on the headline grid where sort dominates) and `crates/kernel-wgpu/` (auto-detects Vulkan/Metal/DX12/GL/WebGPU adapters; deterministic on the popcount path, coarse-deterministic on L2 because WGPU's `f32` is sub-ULP-driver-dependent). Neither is enabled by default; operators register them explicitly. The load-bearing claim is that you can hand ruLake an arbitrary mix of CPU/SIMD/GPU/edge kernels, run on a Raspberry Pi, an AVX-512 server, or an RTX 5080 box, and get bit-identical witnesses on every Fresh / Frozen path no matter which kernel answered.
+
+## Introduction
+
+The intermediary tax on a ruLake cache hit is **1.02× direct RaBitQ** (`crates/rulake/BENCHMARK.md`). The cache is not the bottleneck. When a bottleneck does appear, it appears in the **kernel** — the popcount Hamming scan and the exact L2² rerank — and it scales as `n × D` for the scan and `rerank_factor × k × D` for the rerank. Both become load-bearing past three thresholds: **D ≥ 768** (BERT-large, MPNet, SBERT-large embeddings), **n ≥ 1M** (genomics shards, large-corpus RAG indexes), and **batch ≥ 256 queries per wave** (multi-agent reasoning where the planner fans out). The CPU-naive scan is fine for D=128 / n=100k / batch=1; it is not fine for D=1536 / n=20M / batch=512.
+
+The deployment topology compounds the problem. ruLake's stated targets are not one machine; they are five:
+
+| Target | Accelerator profile |
+|---|---|
+| Laptop / dev | scalar CPU only, sometimes portable SIMD |
+| CI runner | scalar CPU; AVX-512 on x86 hosts that have it |
+| Server / Cloud Run | CPU + AVX-512 or NEON, sometimes a CUDA card |
+| Cognitum box | CPU + dedicated GPU (CUDA / ROCm / Metal) |
+| Browser / Cloudflare Worker / edge | WASM with optional WASM SIMD; no GPU |
+
+If the kernel is hard-wired into the core crate, every one of those targets either fails the build or ships dead-weight bindings. If we feature-gate every option behind `cfg(feature = "cuda")` / `cfg(feature = "wgpu")` / `cfg(feature = "wasm-simd")`, the matrix becomes a permanent maintenance liability and the binary is fixed at compile time — a laptop binary cannot opportunistically use a GPU that is plugged in at runtime, and a server binary forced to fall back to scalar on a CUDA-less node will not survive deploy heterogeneity. The CVE history of "we tried to compile-time-pick a SIMD path" is a parade of "SIGILL on the wrong host."
+
+ADR-157 picks the third option: **a runtime trait, runtime dispatch, and a hard determinism gate on witness-sealed paths.** The trait shape commits to three calls — `id`, `caps`, `scan` — and stays index-stateless so a GPU kernel does not own RaBitQ-index lifetime; ruLake hands it the index by reference per call. The dispatch policy lives in `RuLake::pick_kernel` because only the cache sees the live signals (`batch_size`, `dim`, current `Consistency`) that determine the CPU/GPU crossover; rabitq sees a single-index single-query call and cannot make that decision. The witness chain stays anchored on `(data_ref, dim, rotation_seed, rerank_factor, generation)` and **does not include kernel identity** — kernels are execution substrate; data is what gets sealed. Kernel identity surfaces in stats and logs so operators can answer "which kernel answered the last 1k queries," but it never enters a witness preimage.
+
+The most consequential commitment is the **fail-closed determinism rule**. The popcount Hamming scan is integer math (XOR + popcount + accumulate); every kernel must produce the same byte-equal set of top-k candidates pre-rerank, in the same order, including tie-broken-by-lower-index. The L2² rerank may be float-non-deterministic — IEEE-754 reduction order on a GPU's parallel sum is not the same as scalar left-fold, and the WGPU spec deliberately does not pin sub-ULP behavior across drivers. Kernels declare `caps().deterministic` honestly. Dispatch enforces: **non-deterministic kernels are forbidden on `Consistency::Fresh` and `Consistency::Frozen` paths** and may only answer `Consistency::Eventual` queries (which by design tolerate recall drift). This is the rule that lets the witness chain stay valid across kernel diversity — two ruLake instances on heterogeneous hardware can answer the same Fresh query and produce byte-identical bundles.
+
+Two kernels ship today, and both demonstrate the contract under different constraints. They are the existence proof for ADR-157, not the end of it.
+
+## The decision in detail
+
+### The trait
+
+`VectorKernel` lives in `crates/core/src/kernel.rs` and is exported from the root `rulake` crate. The shape is intentionally small — three methods, no associated types, `Send + Sync` so kernels can live in `Arc<dyn VectorKernel>` and ride between worker threads without ceremony.
+
+```rust
+pub trait VectorKernel: Send + Sync {
+    fn id(&self) -> &str;             // "cpu-naive" | "avx512" | "wgpu" | ...
+    fn caps(&self) -> KernelCaps;     // min_batch, max_dim, deterministic, accelerator
+    fn scan(&self, req: ScanRequest<'_>) -> Result<ScanResponse>;
+}
+```
+
+`ScanRequest<'_>` carries one or more queries, the candidate codes by reference, the `top_k`, and the `dim`; `ScanResponse` carries `top_k` indices + scores per query. The kernel never owns the index — it borrows for the duration of the call. This is the structural decision that lets a GPU kernel exist without coupling to the cache's invalidation lifecycle: when the cache invalidates a generation, in-flight kernel scans against the previous generation are allowed to complete on borrowed memory; the next call binds to the new generation. No GPU-side memory is held by the kernel between calls (the WGPU implementation re-uploads on each `scan`; this is suboptimal for steady-state high-batch workloads and is on the v1.x roadmap to change to a generation-keyed cache).
+
+`KernelCaps` is the only place a kernel can lie to the dispatcher. The four fields are:
+
+| Field | What it pins |
+|---|---|
+| `min_batch: usize` | Below this, dispatch never picks this kernel. CPU kernels report 1; the WGPU kernel reports 64 because transfer overhead dominates below that. |
+| `max_dim: usize` | Hard ceiling. Dim above this triggers a fallback. AVX-512 kernel: `usize::MAX` (no ceiling). WGPU kernel: 4096 (workgroup-size constraint in the current shader). |
+| `deterministic: bool` | The fail-closed flag. AVX-512 kernel: `true` (bit-equal to CpuNaive on the conformance fixture). WGPU popcount kernel: `true`. WGPU L2 kernel: `false` (matches top-k *set* but not raw distances, last-ULP). |
+| `accelerator: &'static str` | Symbolic label for stats. `"cpu"` / `"cpu-simd"` / `"cuda"` / `"metal"` / `"wgpu"` / `"wasm-simd"`. Surfaced in `CacheStats`. |
+
+The dispatch loop is the smallest amount of code that could possibly enforce the contract:
+
+```rust
+fn pick_kernel(&self, batch_size: usize, dim: usize, frozen: bool) -> Arc<dyn VectorKernel> {
+    let deterministic_required = frozen || self.consistency == Consistency::Fresh;
+    for k in self.kernels_by_preference() {
+        let c = k.caps();
+        if batch_size < c.min_batch { continue; }
+        if dim > c.max_dim { continue; }
+        if deterministic_required && !c.deterministic { continue; }
+        return k;
+    }
+    self.default_cpu_kernel()
+}
+```
+
+Preference order is hard-coded most-accelerated-first: `cuda` / `rocm` / `metal` → `wgpu` → `cpu-simd` → `cpu`. ruLake does not ship with GPU kernels enabled. Operators register them explicitly via `RuLake::register_kernel(Arc::new(WgpuKernel::new_blocking()?))` — symmetric with `register_backend`.
+
+### The conformance gate
+
+A new kernel is **promoted past experimental** iff it passes `assert_kernel_conformant(&kernel)` in `crates/core/src/kernel.rs`. The fixture is small and deliberately mean: a clustered D=768 n=1M index with rerank×20 (the ADR-157 reference grid). The assertion checks two things — bit-exact top-k *set* on the popcount-scan phase, and bit-exact ordering tie-broken by lower index. The L2² rerank is held to a coarser test (set match, ordering match, distance equality on integer-arithmetic kernels only). A kernel that fails the gate stays in its experimental crate; it does not land in the default dispatch preference; operators who want it must enable it explicitly with eyes open.
+
+Plus the soft conditions, all measured on the reference grid:
+
+- p95 query latency ≥ 2× lower than CpuNaive at identical recall@10, **or**
+- cost per 1M queries ≥ 30% lower at identical recall@10
+- memory safety: no leak above 2× index bytes during steady-state serving
+- passes the full ruLake smoke suite end-to-end
+
+The acceptance gate exists to stop kernel-vanity: a GPU kernel that demonstrates a 1.3× win at D=128 n=10k batch=1 is not interesting because that workload runs faster on a single CPU core anyway. The gate forces measurement at the only point where a kernel decision is load-bearing.
+
+### Crate placement
+
+The trait is in the core `rulake` crate (`crates/core/src/kernel.rs`) because every consumer needs the trait shape to write `register_kernel` calls. Implementations are sibling crates — never workspace members, never feature-gated submodules of the core crate, per ADR-001:
+
+| Crate | What it ships |
+|---|---|
+| `rulake` (core) | `VectorKernel` trait, `CpuNaiveKernel` baseline, `assert_kernel_conformant` fixture, `KernelCaps`, dispatch policy, `register_kernel` API |
+| `crates/kernel-avx512/` | `Avx512Kernel`, runtime CPUID gate, `target_feature`-scoped intrinsics |
+| `crates/kernel-wgpu/` | `WgpuKernel`, WGSL shaders, fail-closed adapter request, host-side top-k sort |
+| `kernel-cuda` (future, separate repo) | CUDA bindings, license footprint isolated |
+| `kernel-metal` (future, separate repo) | Metal Performance Shaders bindings |
+
+Feature-gated kernels inside the core crate were rejected (ADR-157 §A) because every GPU dependency is 1k+ lines of FFI plus a driver matrix plus its own CI pain — pulling CUDA into `rulake` breaks laptop and WASM builds unless everything is feature-gated, and feature-gate matrices are a maintenance sink that scales poorly across five deployment targets. Separate crates amortize the pain and let customers pick the one their platform supports. WASM SIMD is the one exception — it's the same source compiled with `--target=wasm32-*`, so it lives feature-gated inside the core crate for the WASM path, not as a separate repo.
+
+### The two shipped kernels
+
+**`crates/kernel-avx512/` — the host SIMD kernel.** Wraps `_mm512_sub_ps` + `_mm512_fmadd_ps` for the L2² inner loop and `_mm512_popcnt_epi64` (the `avx512vpopcntdq` extension) for the Hamming popcount. Both paths are bit-equal to `CpuNaiveKernel` on the conformance fixture — the SIMD math is integer-arithmetic on the popcount side and FMA on the L2 side, and the FMA is fused-multiply-add which produces the same result as `(a*b)+c` to within zero ULP, so the L2 path stays deterministic too. Construction is `Avx512Kernel::new() -> Option<Self>` — `Some` iff the host CPU advertises **all four** of `avx512f`, `avx512bw`, `avx512vl`, `avx512vpopcntdq`; `None` otherwise. This is the runtime feature-detection that lets a single binary ship to mixed fleets without SIGILL. Safety is localized: every `unsafe` block is inside a `#[target_feature(enable = ...)]` function, every entry into those functions is gated on the `Some(_)` constructor path. Bench result on the headline grid (D=384, n=16384, top_k=10): **~2.5% faster than CpuNaiveKernel.** The reason it's not larger is that the sort dominates — at this grid the popcount/L2 inner loop is already cheap enough that AVX-512 only shaves a small slice. The win materializes at high D and large n, which is exactly where the CPU baseline gets expensive.
+
+**`crates/kernel-wgpu/` — the portable GPU kernel.** Runs the inner loops on whatever compute-capable backend wgpu finds at startup: **Vulkan / Metal / DX12 / GL / WebGPU**. On the test bench (NVIDIA RTX 5080 via Vulkan) wgpu picks the discrete GPU automatically. Two WGSL shaders: an L2 path (`shaders/l2.wgsl`, one workgroup over the candidate batch, one thread per (query, candidate) distance, reduction on host) and a popcount path (`shaders/popcnt.wgsl`, packed 1-bit codes XORed and popcounted per `u32` lane via `countOneBits`). The key trick is that **only the per-candidate distance is computed on GPU; the top-k sort runs on the host with the same byte-equal tie-break the naive kernel uses.** This is what lets the GPU path stay deterministic on the popcount conformance fixture — the scan is integer arithmetic on both sides and the host-side sort is shared. The L2 path is *not* bit-equal to CpuNaive because WGSL `f32` operators are IEEE-754 but the WGPU spec doesn't pin sub-ULP behavior across drivers; top-k *set* matches and distance ordering matches, but raw distances may differ in the last ULP. Conformance therefore exercises the popcount path (exact) and a coarse L2 path (set, not raw distances). Construction is `WgpuKernel::new_blocking() -> Result<Self>` — `Ok` iff wgpu can request an adapter + device; `Err(WgpuKernelError::NoAdapter)` on headless CI hosts (callers fall back to CpuNaiveKernel). Bench result on the headline grid: **7.4 ms vs 2.85 ms for AVX-512** — i.e., the GPU loses on this grid because host↔device transfer dominates over the work. The kernel earns its keep at higher D and / or larger batch where transfer is amortized.
+
+The two kernels together are the existence proof: same trait, same conformance fixture, two different accelerator categories (host SIMD intrinsics vs portable GPU shader), both deterministic on the witness-relevant path, both fail-closed at construction so a binary with both crates linked just falls back gracefully on a host that has neither AVX-512 nor a GPU.
+
+### Determinism, witness, and dispatch interaction
+
+The witness chain stays anchored on `(data_ref, dim, rotation_seed, rerank_factor, generation)` regardless of which kernel answered. This is the **load-bearing structural decision** — kernel identity does not enter the witness preimage. If the witness changed per kernel, two ruLake instances on heterogeneous hardware could not agree on a bundle hash even though both saw the same data, which would break the cross-host trust contract that the SHAKE-256 witness exists to enforce. The dispatcher's job is to make sure the choice of kernel never matters for the bytes returned on a witness-sealed path — and that's done by the `deterministic` caps bit plus the Fresh/Frozen filter.
+
+The escape hatch for non-deterministic kernels is `Consistency::Eventual`. An operator who knowingly enables a non-deterministic GPU kernel on an Eventual collection accepts that top-k orderings may differ across restarts; the caps bit is the warning sign and the deployment doc spells it out as a first-class operational concern. The current dispatch policy refuses to use a non-deterministic kernel on Frozen (audit-tier reproducibility) outright; this is the conservative read of "Frozen means bit-reproducible and that means kernel-independent."
+
+| trade-off | what got picked | what got rejected | why |
+|---|---|---|---|
+| trait location | `rulake` core | `ruvector-rabitq` (kernels are RaBitQ primitives) | every consumer needs the trait shape; cache is the only place that sees batch-size signals |
+| dispatch location | `RuLake::pick_kernel` | inside `ruvector-rabitq` per-call | rabitq sees one query, one index — can't make a CPU/GPU crossover decision |
+| GPU kernel placement | sibling crates per backend | feature-gated submodules of core | feature-matrix scales poorly across CUDA / ROCm / Metal / wgpu / WASM-SIMD |
+| WASM SIMD | feature gate inside core | separate `rulake-wasm-simd` crate | same source compiled with `--target=wasm32-*`; no new crate needed |
+| determinism | hard gate via `caps().deterministic` + dispatch filter | trust the kernel author | non-deterministic GPU rerank is a real category; explicit caps + filter is the only honest read |
+| witness anchoring | `(data_ref, dim, rotation_seed, rerank_factor, generation)`, kernel identity excluded | include kernel id in witness | heterogeneous hardware would never agree on bundles |
+| acceptance gate | 2× p95 lower OR 30% cost lower at identical recall@10 | "feels faster" | stops kernel-vanity at workloads where the choice doesn't matter |
+| construction shape | fail-closed `Option`/`Result` from `new()` | panic on missing CPUID / adapter | mixed-fleet binary must run unchanged on hosts that lack the accelerator |
+| acceptance fixture | clustered D=768 n=1M rerank×20 | small grids | the only point where kernel choice is load-bearing |
+| top-k sort | always on host, never on GPU | GPU sort | host-side sort is the deterministic shared step that lets GPU L2 stay coarse-deterministic |
+
+## What ships today, what's next
+
+Two kernels: AVX-512 host SIMD (bit-equal, ~2.5% headline win where sort dominates, real win at high D), and wgpu portable GPU (auto-detects every wgpu-supported backend, deterministic popcount, coarse L2). Both pass `assert_kernel_conformant` on the popcount path; both are off-by-default and registered explicitly. The conformance test in `crates/core/src/kernel.rs` is the only path past experimental — no kernel ships in the default dispatch preference until it crosses the gate.
+
+The trait shape was deliberately designed to accommodate `wgpu` when wgpu's compute capabilities matured (ADR-157 §E rejected wgpu in 2026-04 because the shader model didn't yet expose popcount + reduction primitives that match native CUDA on the scan phase; eight months later wgpu's `countOneBits` plus storage-buffer atomics made it viable). The same shape accommodates a future CUDA / ROCm / Metal kernel (separate crates per ADR-157 §A) and a WASM SIMD path inside the core crate (open question 1; current direction is feature-gate not separate crate). Open questions still open: kernel identity in `CacheStats` exposure (open question 5; useful but scope-creep toward observability that should live in tracing); empirical batch-size autotuning to replace the conservative static `min_batch` hint (open question 3; deferred until a third kernel exists to measure against); and whether `Consistency::Frozen` should warn instead of refuse on non-deterministic kernels (open question 4; current answer is refuse, on the read that "Frozen means bit-reproducible and that means kernel-independent").
+
+The accelerator plane is, in short, the plumbing that lets ruLake stay one binary across a Raspberry Pi and an RTX 5080 box without making the witness chain pretend either of them is the other.
+
+---
+
+**Repo:** [ruvnet/RuLake](https://github.com/ruvnet/RuLake) · **Live demo:** <https://ruvnet.github.io/RuLake/> (auto-probes the live MCP at [`https://rulake-mcp.ruv.io/`](https://rulake-mcp.ruv.io/)) · **ADR:** [`docs/adrs/ADR-157-optional-accelerator-plane.md`](../adrs/ADR-157-optional-accelerator-plane.md) · **Crates:** [`crates/kernel-avx512/`](../../crates/kernel-avx512/) · [`crates/kernel-wgpu/`](../../crates/kernel-wgpu/)

--- a/docs/userguide/01-getting-started.md
+++ b/docs/userguide/01-getting-started.md
@@ -1,0 +1,92 @@
+# 01 — Getting started
+
+The fastest way to see ruLake working is to open the hosted Console. No
+install, no auth, no signup. The page is a Vite-built static SPA hosted on
+GitHub Pages and the MCP it talks to is a Cloud Run service in `us-central1`.
+
+> Open: [https://ruvnet.github.io/RuLake/](https://ruvnet.github.io/RuLake/)
+
+![ruLake Console — Stats screen with the LIVE pill in the top right](../../assets/console-hero.png)
+
+## What happens on boot
+
+1. The Console loads in **DEMO mode** with fixture data. The top-right
+   endpoint pill reads `○ DEMO · no live MCP`.
+2. A fire-and-forget probe runs against `https://rulake-mcp.ruv.io/`. The
+   probe is a real MCP `initialize` over Streamable HTTP — same wire shape
+   the Connect screen exercises by hand.
+3. If the probe succeeds, `window.RULakeActiveClient` is populated with the
+   session id and the topbar pill flips to `● LIVE · rulake-mcp.ruv.io`.
+4. If the probe fails (cert pending, offline, your firewall, your VPN), the
+   pill stays at DEMO and the rest of the Console keeps using fixtures.
+
+The probe lives in `ui/src/components/screens.jsx` inside `Topbar`'s effect.
+Failure is silent by design — you should never see a toast for "couldn't
+reach the demo MCP".
+
+## What you'll see (left to right)
+
+- **Sidebar** — seven routes (Stats, Playground, Backends, Bundle, Audit,
+  Connect, App store). Each row carries a small badge: `live`, `WARM`, the
+  current audit row count, the current connection count.
+- **Topbar tabs** — three environment scopes (`lake-prod`, `lake-eu`,
+  `lake-edge`). The Stats and Browse screens scale their numbers to whichever
+  is active. Default is `lake-prod`.
+- **Endpoint pill** — top-right. Shows live/demo state and the connected
+  host. Hover for the session id.
+- **Witness HUD** — bottom of the sidebar. Live SHAKE-256 hex, the bundle
+  it belongs to, and a green `● MATCH` indicator.
+
+## Keyboard shortcuts
+
+The Console has a deliberately small shortcut surface. The bindings are in
+`ui/src/components/help.jsx`.
+
+| Key | Where it works | What it does |
+|---|---|---|
+| `?` | Anywhere outside an input | Open the Help index modal |
+| `Esc` | Any open modal | Close it |
+| `⌘ + Enter` | Playground query box | Send the query (mac) |
+| `Ctrl + Enter` | Playground query box | Send the query (win/linux) |
+
+Any time you see a small `?` icon next to a section header, click it for
+context-specific docs. The help system is keyed by topic id, so the same
+copy is reachable from both the icon and the index.
+
+## Two ways to run real code
+
+The Console can drive **either** of these without you changing anything in
+the URL bar:
+
+1. **Through the wire** — when the topbar pill is `● LIVE`, every
+   Playground query, every Browse refresh, and every Bundle recompute
+   issues a real `tools/call` to the connected MCP. The audit ledger fills
+   with rows whose principal is `jules@ruv` (the demo principal — change it
+   on your own deploy via JWT claims).
+2. **WASM-local** — the bundle of `rulake-wasm` shipped with the Console
+   gives the Bundle screen a `computeWitness` function that runs entirely in
+   your browser. The IPFS strip on the Bundle screen pairs with this:
+   `paste a CID → fetch from a public gateway → recompute the witness
+   locally`. No network round-trip to a server.
+
+Pick whichever fits — for the screens that follow, both produce real audit
+rows in the local IndexedDB.
+
+## Where state lives
+
+Everything the Console "remembers" is in your browser:
+
+- **IndexedDB** — saved connections, pinned bundles, saved queries, the
+  audit tail.
+- **localStorage** — the substrate animation settings (density, speed).
+- **JS memory only** — bearer tokens, JWT strings. They are never persisted
+  past a page reload, by design.
+
+You can wipe the lot from devtools `Application > Storage > Clear site data`
+if you want a clean slate. The Connect screen also exposes a `Clear local`
+button on the Audit screen.
+
+## Next
+
+When you have the topbar pill green, head to [02 — Stats screen](./02-stats-screen.md)
+for a tour of the home view.

--- a/docs/userguide/02-stats-screen.md
+++ b/docs/userguide/02-stats-screen.md
@@ -1,0 +1,121 @@
+# 02 — Stats screen
+
+The Stats screen is the landing route. It is a 1 Hz live tail of the metrics
+the cache layer publishes via `rulake://stats` plus a per-backend rollup
+that mirrors `rulake://stats/by-backend`.
+
+![Stats screen with six tile counters, throughput chart, latency histogram, refusal breakdown and the vector substrate animation](../../assets/console-hero.png)
+
+## Header — env scope
+
+The thin coloured strip across the top reflects whichever environment tab
+you have selected in the topbar:
+
+- `lake-prod` (green) — `us-west · primary`, full traffic
+- `lake-eu` (cyan) — `eu-west · replica`, ~42% load
+- `lake-edge` (amber) — `pop-* · degraded`, ~8% load with elevated refusals
+
+The numbers in every tile and chart are scaled to the active env. The
+`load` percentage on the right is the multiplier applied to the
+production baseline.
+
+Two buttons live in the pane header next to the `● LIVE · 1.0 Hz` strip:
+
+- **Pause** — freezes the substrate animation and the tile sparklines.
+- **Export JSONL** — downloads a 2-line newline-delimited JSON snapshot of
+  the current envelope. Useful for pasting into an issue or a notebook.
+
+## The six tiles
+
+Reading them left to right:
+
+| Tile | What it counts | Source of truth |
+|---|---|---|
+| **Hits** | Cache hits over the rolling window | `CacheStats::hits` |
+| **Misses** | Cache misses (forced backend pulls) | `CacheStats::misses` |
+| **Hit rate** | `hits / (hits + misses)` as % | `CacheStats::hit_rate()` |
+| **Primes** | Cache fills (backend pulls + RaBitQ build) | `CacheStats::primes` |
+| **Refused** | Honest refusals — see below | aggregated from MCP audit |
+| **Witnesses verified** | Successful SHAKE-256 verifications | `read_from_dir` outcomes |
+
+Each tile carries a sparkline of the last ~30 ticks and a delta line under
+the value (e.g. `+218/min`). The hit-rate tile shows the ADR-155 acceptance
+target of `≥ 95%` as text — anything under that on a steady workload is the
+signal that the cache is being fought by either invalidation churn or a
+freshness-budget too tight for the backend's generation cadence.
+
+## Throughput + latency
+
+Below the tiles are two charts:
+
+- **Query throughput · 60s window** — three coloured lines, one per
+  backend. The y-axis is `q/s`. Useful for spotting sudden traffic shifts
+  between regions.
+- **Latency p50 / p99** — a histogram bucketed at `0 / 5 / 10 / 25 / 50 /
+  100ms`. p50 and p99 numerals are repeated below the histogram for
+  at-a-glance reading. Production p50 sits around 8–12 ms; edge can spike
+  to ~18 ms at p50 and 60+ at p99.
+
+## Per-backend rollup
+
+The lower-left table is sourced from the same data the
+`rulake://stats/by-backend` resource serves. Columns:
+
+| Column | Meaning |
+|---|---|
+| `Backend` | Adapter id (e.g. `lake-prod`) — green dot = verified |
+| `Region` | Free-form locality string from the adapter |
+| `Hits` / `Miss` | Sum across all collections in that backend |
+| `HR%` | Hit rate as a one-decimal percentage |
+| `Prime ms` | Mean cold-prime cost across collections that have primed |
+| `Witness` | Truncated SHAKE-256 of the head collection |
+
+## Refusal breakdown
+
+Top-right of the lower row. Five rows, each `<CODE> <count> <bar>`. The
+amber bar is normalised against the largest count in the window (so the
+biggest bar is always full-width — read it as relative pressure, not
+absolute).
+
+Codes you will actually see on a healthy server:
+
+- **`WITNESS_MISMATCH_REFUSED`** — server's witness disagrees with the
+  recomputed one. Always-refuse, never-degrade.
+- **`STALE_BUNDLE_GUARD`** — the cached generation is older than the
+  freshness budget for the consistency mode in use. Refusal under `Fresh`,
+  fallback under `Eventual`.
+- **`STALE_BUNDLE_FALLBACK`** — same root cause as the guard, but the
+  consistency mode allowed degraded service so the request returned with a
+  warning instead of a refusal.
+- **`POLICY_DENIED`** — JWT scope or `pii_policy` rejected the call.
+- **`BUDGET_EXCEEDED`** — query exhausted its `budget.max_latency_ms`.
+
+The "honest refusals" stripe under the breakdown is intentional copy: a
+refusal is the planner declining to serve a query whose witness, freshness,
+or capability budget would be violated. Treat the count as a system-working
+indicator, not as an error.
+
+## Vector substrate (ambient)
+
+The animation strip at the bottom is decorative. The gear icon to the right
+of the section header opens a popover with three knobs:
+
+- `density` — point count multiplier
+- `speed` — frame-rate multiplier
+- `perspective` — z-axis tilt multiplier
+
+Plus toggles for the orbit ring and the witness halo. Settings persist to
+`localStorage` under `rulake-substrate`. They have no effect on any
+operational behaviour.
+
+## Where the numbers come from
+
+In `● LIVE` mode the Console polls `rulake://stats` and renders. In demo
+mode it scales a deterministic fixture (`ui/src/lib/data.js`) so the screen
+still reads usefully without a server. The `lake-prod` baseline is the real
+shape; `lake-eu` and `lake-edge` are derived multipliers.
+
+If you need the same tiles in your own monitoring, the wire form is
+straightforward — see [05 — Backends and collections](./05-backends-and-collections.md)
+for the resource schema, and [09 — Live MCP setup](./09-live-mcp-setup.md)
+for getting your own server up.

--- a/docs/userguide/03-app-store.md
+++ b/docs/userguide/03-app-store.md
@@ -1,0 +1,107 @@
+# 03 — App store
+
+The App store route is a static catalog of substrates that compose with
+ruLake. It is not a marketplace — there is nothing to buy and nothing to
+download from this screen. It exists to answer one question: *what other
+crates plug into the same witness-anchored cache, and where is each one in
+its lifecycle?*
+
+![App Store screen listing four substrates with status tags and install commands](../../assets/console-appstore.png)
+
+## How to read an entry
+
+Each card has the same six regions:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ <name>  · <one-line tag>                              [STATUS]  │
+│ <pitch — 2-3 sentences on what this adds>                       │
+│                                                                 │
+│ ADDS                              INSTALL                       │
+│ · <tool name 1>                   $ cargo add <crate>           │
+│ · <tool name 2>                   $ cargo run -p <mcp crate>    │
+│ · <tool name 3>                   ● live · <hosted url>         │
+│ · ...                             $ npm install <pkg>           │
+│                                                                 │
+│ tier: <runtime tier descriptor>          ADR ↗   gist ↗   research/ ↗
+└─────────────────────────────────────────────────────────────────┘
+```
+
+- **Name + tag** — short product name and a pitch-line.
+- **Status pill** (top right) — see "Status tags" below.
+- **Pitch** — what the substrate adds to the agentic memory model.
+- **ADDS** — the new MCP tools / capabilities the substrate brings
+  alongside the core eight `rulake-mcp` tools.
+- **INSTALL** — a stack of one-liners. Rust crate first, then the MCP
+  companion server, then the live URL if hosted, then npm and any browser
+  surface.
+- **Footer links** — ADR (the design decision), gist (a 2,500–3,700 word
+  deep companion), and `research/` (benchmarks, security reviews).
+
+## Status tags
+
+The tag colour and text correspond to the substrate's lifecycle stage. The
+mapping is deliberate — no marketing inflation.
+
+| Tag | What it actually means | When to use it |
+|---|---|---|
+| `SHIPPING` (green) | Source code lives in `crates/<name>/`, tests are green on CI, an MCP companion or Rust API is usable today. | Production-eligible. Read the ADR for the supported tier matrix. |
+| `SCAFFOLDED` (amber) | Crate exists, design is ratified in an ADR, but only a v0.0.1 surface is implemented. Behaviour is real; coverage is partial. | Try it. Expect rough edges and `Proposed` items in the ADR roadmap. |
+| `PROPOSED` (warm) | ADR exists; no source. | Read the ADR if curious. Don't depend on it. |
+| `ROADMAP` (cool) | Future intent only. | Information-only. |
+
+The Console currently ships four cards, all `SHIPPING`:
+
+- **rvDNA v2** — genomic intelligence substrate
+  ([ADR-007](https://github.com/ruvnet/RuLake/blob/main/docs/adrs/ADR-007-rvdna-as-rulake-substrate.md)).
+  Five MCP tools via `mcp-rvdna`; live demo at
+  [`rvdna-mcp.ruv.io`](https://rvdna-mcp.ruv.io/).
+- **ruQu v2** — quantum execution intelligence substrate
+  ([ADR-008](https://github.com/ruvnet/RuLake/blob/main/docs/adrs/ADR-008-ruqu-as-rulake-substrate.md)).
+  Five MCP tools via `mcp-ruqu`; live demo at
+  [`ruqu-mcp.ruv.io`](https://ruqu-mcp.ruv.io/).
+- **gcs-backend** — Parquet on Google Cloud Storage
+  ([ADR-155](https://github.com/ruvnet/RuLake/blob/main/docs/adrs/ADR-155-rulake-datalake-layer.md)).
+  Storage adapter; cache coherence rides per-object generation tokens.
+- **ipfs-backend** — witness-anchored bundle distribution
+  ([ADR-005](https://github.com/ruvnet/RuLake/blob/main/docs/adrs/ADR-005-ipfs-backend-and-deploy.md)).
+  Three modes: kubo, gateway-only, kubo + gateway-fallback.
+
+## How a substrate plugs in
+
+Every substrate in this catalog implements `BackendAdapter` from
+`crates/core/src/backend.rs`. That trait is four methods:
+
+```rust
+pub trait BackendAdapter: Send + Sync {
+    fn id(&self) -> &str;
+    fn list_collections(&self) -> Result<Vec<CollectionId>>;
+    fn pull_vectors(&self, collection: &str) -> Result<PulledBatch>;
+    fn generation(&self, collection: &str) -> Result<u64>;
+    // Optional — return the bundle the cache should anchor to.
+    fn current_bundle(&self, collection: &str) -> Result<Option<RuLakeBundle>> { Ok(None) }
+}
+```
+
+That is the entire integration surface. Implement it once per substrate and
+ruLake's federation, witness, audit, and consistency modes work without any
+substrate-specific special-casing in the core.
+
+## Live demo links
+
+For substrates with a hosted MCP, the install card includes a `● live · <url>`
+line. Click it to open the substrate's own MCP endpoint in a new tab — you
+will get a 405 (it only accepts POST), which confirms the server is up.
+Use the [04 — Connect](./04-connect.md) screen to point the Console at any
+of these instead of the default `rulake-mcp.ruv.io`.
+
+## Where to look in the source
+
+| File | What it holds |
+|---|---|
+| `ui/src/components/screens.jsx` `AppStoreScreen` | The card data + render |
+| `crates/<name>/` | Each substrate's Rust crate |
+| `crates/mcp-<name>/` | The matching MCP companion server |
+| `docs/adrs/ADR-NNN-*.md` | Design decision per substrate |
+| `docs/gists/<name>-deep.md` | Long-form prose companion (2.5k+ words) |
+| `docs/research/<name>/` | Benchmarks, security reviews |

--- a/docs/userguide/04-connect.md
+++ b/docs/userguide/04-connect.md
@@ -1,0 +1,152 @@
+# 04 — Connect
+
+The Connect screen is where you tell the Console which `rulake-mcp` server
+to drive. It is also where you save additional endpoints and pick an auth
+mode. All credentials are kept in your browser — IndexedDB for the saved
+list, JS memory only for the live token.
+
+![Connect screen — endpoint URL, auth mode segmented control, JWT textarea, capability matrix](../../assets/console-connect.png)
+
+## The default endpoint
+
+Out of the box the endpoint field is pre-filled with:
+
+```
+https://rulake-mcp.ruv.io/
+```
+
+That is the project's reference Cloud Run deploy. It runs `rulake-mcp` with
+`--auth none --insecure-allow-no-auth --capabilities read,publish,admin`,
+so the Console can `tools/list` and `tools/call` without any token. See
+[09 — Live MCP setup](./09-live-mcp-setup.md) for the deploy story.
+
+If you change the endpoint, the change does not auto-save. Click
+**Save endpoint** to persist it. Click **Connect & initialize** (or
+**Test only** — they call the same handler) to actually drive the wire.
+
+## What "● LIVE" means in the topbar
+
+The pill in the top-right of every screen shows one of:
+
+- **`○ DEMO · no live MCP`** — `window.RULakeActiveClient` is unset. Every
+  screen renders fixture data.
+- **`● LIVE · <host>`** — `window.RULakeActiveClient` is populated with a
+  real MCP session id. Browse, Bundle, and Playground will dispatch real
+  `tools/call` requests against that endpoint.
+
+The pill flips on two events:
+
+1. **Boot probe** — the Console tries `https://rulake-mcp.ruv.io/`
+   automatically on first paint. Silent success → green pill. Silent
+   failure → stay at DEMO.
+2. **Connect → Test/Connect button** — same handshake, but with whatever
+   endpoint and token you have entered. Green pill on success, with the
+   host you pointed at.
+
+The handshake itself is the standard MCP Streamable HTTP dance:
+
+```bash
+# 1. initialize — server sets mcp-session-id response header
+curl -isS -X POST https://rulake-mcp.ruv.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+       "params":{"protocolVersion":"2024-11-05",
+                 "capabilities":{},
+                 "clientInfo":{"name":"manual","version":"0"}}}'
+
+# 2. notifications/initialized — same session id from step 1
+curl -sS -X POST https://rulake-mcp.ruv.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'mcp-session-id: <session-from-step-1>' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+# 3. tools/list — same session
+curl -fsS -X POST https://rulake-mcp.ruv.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'mcp-session-id: <session>' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+The Console's status line under the action buttons reports the round-trip:
+`← initialize OK · 187ms · 8 tools · session 7f3c2a91…`. The "8 tools" count
+is the contract for the read+publish+admin capability set.
+
+## Auth modes
+
+The segmented control offers four. Pick the one your server is configured
+for; the default and the hosted demo are both `none`.
+
+| Mode | What the Console sends | Use case |
+|---|---|---|
+| **No auth** | No `Authorization` header | Loopback, demo, dev |
+| **Bearer** | `Authorization: Bearer <token>` | Static API key in front of mcp-server |
+| **JWT** | `Authorization: Bearer <jwt>` | OAuth / PKCE; scope claims drive per-tool caps |
+| **mTLS** | (cannot be done from the browser — see below) | Production with client-cert pinning |
+
+### JWT specifics
+
+The JWT field expects a serialized token. Once connected, the server
+applies per-call caps from the scope claim. The expected shape is:
+
+```
+aud:    https://rulake.ruv.net
+scope:  mcp:rulake:read mcp:rulake:publish
+```
+
+Per-claim cap enforcement landed in mcp-server v0.8 (see commit `67fc821`
+on `main`). If the JWT's scope is missing a capability, the matching tool
+will return `POLICY_DENIED` with the specific claim name.
+
+### Why mTLS is greyed out from the browser
+
+The TLS handshake selects the client certificate before any JavaScript
+runs. Browsers expose no API to control that selection per fetch. The
+Console renders a warning strip:
+
+> mTLS needs a non-browser client. The TLS handshake picks the client cert
+> before any JavaScript runs. Use `rulake/http` from Node.js or
+> `rulake-cli` instead.
+
+For an mTLS-fronted server, put a Bearer/JWT proxy in front for browser
+callers, or skip the Console and use the SDKs.
+
+## Saving and switching endpoints
+
+The **Save endpoint** button writes a row into IndexedDB:
+`{label, endpoint, mode, token}`. The token is stored only as the first 8
+characters with an ellipsis (e.g. `eyJhbGci…`) — never the whole secret.
+
+**Saved (N)** opens a list of every saved row. Click one to populate the
+fields; click Connect to switch the active client. The audit ledger gains
+an `INIT_OK` row each time, with the new endpoint as the target.
+
+## The capability matrix
+
+Below the form is a three-row table:
+
+| Capability | Tools | Resources | Status |
+|---|---|---|---|
+| `read` | `rulake_query` · `list_backends` | `rulake://stats · …/by-backend · …/bundle/*` | GRANTED on the demo |
+| `publish` | `rulake_publish_bundle` · `refresh` · `invalidate` | — | GRANTED on the demo |
+| `admin` | `save_cache` · `warm_from_dir` · `audit_tail` | — | NOT REQUESTED on the demo |
+
+The actual GRANTED / NOT REQUESTED state comes from the JWT scope claim on
+your token (or from the `--capabilities` flag the operator passed to
+`rulake-mcp` when there is no token). On the hosted demo all three show
+green because the server runs with `--capabilities read,publish,admin`.
+
+## Storage & runtime settings card
+
+Below the connect card sits the **Storage settings** card. Two unrelated
+toggles live there:
+
+- **Embedding provider** — pick which API key to use when the Playground
+  calls `text-embedding-3-small`. Keys are kept in JS memory only.
+- **Workers** — when on, vector search is offloaded to a Web Worker.
+  Default is off.
+
+These settings persist to IndexedDB (under the `kv` store) so they survive
+a reload.

--- a/docs/userguide/05-backends-and-collections.md
+++ b/docs/userguide/05-backends-and-collections.md
@@ -1,0 +1,134 @@
+# 05 — Backends and collections
+
+The Backends route is where you browse what the connected MCP exposes. In
+demo mode it shows three fixture backends; in `● LIVE` mode it calls the
+real `rulake_list_backends` tool, then `rulake_list_collections` per
+backend, and renders whatever comes back.
+
+![Backends browser with three lakes, seven collections, federation graph and cache pressure bars](../../assets/console-browse.png)
+
+## What a "backend" is
+
+A backend is a Rust struct that implements the `BackendAdapter` trait from
+`crates/core/src/backend.rs`. The trait is four required methods plus one
+optional:
+
+```rust
+pub trait BackendAdapter: Send + Sync {
+    fn id(&self) -> &str;
+    fn list_collections(&self) -> Result<Vec<CollectionId>>;
+    fn pull_vectors(&self, collection: &str) -> Result<PulledBatch>;
+    fn generation(&self, collection: &str) -> Result<u64>;
+    fn current_bundle(&self, collection: &str)
+        -> Result<Option<RuLakeBundle>> { Ok(None) }
+}
+```
+
+Today the repo ships:
+
+| Crate | Adapter | Purpose |
+|---|---|---|
+| `crates/core/` | `LocalBackend` | In-memory reference impl |
+| `crates/core/` | `FsBackend` | `ruvec1` binary on disk; mtime as generation |
+| `crates/gcs-backend/` | `GcsBackend` | Parquet on Google Cloud Storage |
+| `crates/ipfs-backend/` | `IpfsBackend` | `table.rulake.json` over kubo/gateway |
+| `crates/rvdna-backend/` | T0/T1/T2 tiered | `.rvdna` v2 genomic files |
+| `crates/ruqu-backend/` | StateVector / Stabilizer / TensorNetwork / hardware-stub | Quantum sim collections |
+
+Adding your own is the four methods above. Once registered with
+`RuLake::add_backend`, every Console screen — federation graph, witness
+chain, audit tail — renders it without any further plumbing.
+
+## What a "collection" is
+
+A collection is a named set of vectors inside one backend, addressed as
+`(backend_id, collection_id)`. The Console treats the pair as the primary
+key for everything: cache pointer, bundle witness, audit row target,
+publish target.
+
+A collection row in the table carries:
+
+| Column | Meaning |
+|---|---|
+| `Collection` | id (e.g. `memories`, `docs.public`) |
+| `Dim` | vector dimensionality |
+| `Generation` | `Num(N)` (numeric, monotonic) or `Opaque(<bytes>)` (CA hash) |
+| `Entries` | vector count in the cached snapshot |
+| `Hits` / `Miss` | per-collection counters since last reset |
+| `Last prime` | most recent cold-prime cost in ms |
+| `State` | `WARM` / `COLD` / `DEGRADED` (see below) |
+| `Witness` | first 16 hex of the SHAKE-256(32) bundle witness |
+
+## State tags
+
+The four colour-coded tags carry a precise meaning:
+
+- **`VERIFIED`** (green) — internal health flag for the row, set when the
+  most recent witness check passed.
+- **`WARM`** — cache entry is live, serving searches without a backend
+  round-trip.
+- **`COLD`** — registered but never primed. First search will pull
+  vectors from the backend.
+- **`DEGRADED`** — cache entry exists but the most recent coherence check
+  found the backend's generation drifted past the freshness budget. Search
+  works under `Eventual` consistency; refuses under `Fresh`.
+
+## Toolbar — Refresh and Publish
+
+**Refresh** issues two MCP calls:
+
+```
+rulake_list_backends         → ["lake-prod", "lake-eu", ...]
+rulake_list_collections {b}  → ["memories", "docs.public", ...]   per backend
+```
+
+The audit tail gains a `LIST_COLLECTIONS_OK` row on success or
+`LIST_COLLECTIONS_FAILED` on error. In `● LIVE` mode the row count
+populates `window.RULakeLiveCollections` and re-renders the table with
+real backends + collections.
+
+**Publish** queues a `rulake_publish_bundle` for the currently-selected
+row. The audit tail gains `PUBLISH_QUEUED`. The actual MCP call and
+generation bump happen server-side; refresh after a beat to see the new
+witness.
+
+> If you click Publish without selecting a row first, you get a toast
+> reminding you to click any row, then Publish.
+
+## Cache pressure (per backend)
+
+The lower-left card shows working-set / budget as a percentage bar per
+backend. Bars turn amber above 85%. The percentage is illustrative in
+demo mode; in `● LIVE` mode it reads from the same per-backend rollup the
+Stats screen uses.
+
+## Federation topology
+
+The lower-right card is a small canvas-rendered graph showing the
+planner → backends → collections fan-out, with a moving particle along
+each edge to indicate live request flow. Coloured dots:
+
+- green = `WARM`
+- amber = `DEGRADED`
+- grey = `COLD`
+
+The graph is read-only; click a row in the table above to drill into a
+specific collection's bundle.
+
+## Drilling into a row
+
+Click any row to select it (a green dot fills in the leftmost column).
+Click the **Open** button at the right end of the row to jump to the
+[06 — Bundle / witness viewer](./06-bundle-witness-viewer.md) for that
+`(backend, collection)`.
+
+## Working entirely off-wire
+
+In demo mode the table renders three backends:
+- `lake-prod` (gcs, 4 collections)
+- `lake-eu` (fs, 2 collections)
+- `lake-edge` (ipfs, 1 collection)
+
+The fixture data is in `ui/src/lib/data.js` under `BACKENDS`. It exists so
+the screen reads usefully when the demo MCP is unreachable. None of these
+fixture rows are wired to a live backend — refresh has no effect on them.

--- a/docs/userguide/06-bundle-witness-viewer.md
+++ b/docs/userguide/06-bundle-witness-viewer.md
@@ -1,0 +1,142 @@
+# 06 — Bundle / witness viewer
+
+The Bundle screen is the load-bearing trust surface. Every cached entry in
+ruLake is anchored by a SHAKE-256(32) witness over a small canonical
+descriptor — the bundle. This screen renders that descriptor, recomputes
+the witness in your browser, and compares the two. They must match. That
+is the contract.
+
+![Bundle viewer with key-value descriptor on the left, witness comparator showing BIT-EXACT MATCH, generation chain, and a printed receipt on the right](../../assets/console-bundle.png)
+
+## What is a bundle?
+
+`RuLakeBundle` is a ~300-byte JSON sidecar called `table.rulake.json`. It
+travels with the data — in object storage next to the Parquet, on IPFS
+under its own CID, or inline in the MCP response. The struct (in
+`crates/core/src/bundle.rs`) carries:
+
+| Field | What it pins | Notes |
+|---|---|---|
+| `format_version` | The bundle schema | Currently `2`; included in the witness preimage so a v1 and v2 bundle with otherwise-identical fields produce different witnesses. |
+| `data_ref` | URL of the actual vector bytes | e.g. `rvf://seg/0x11/<hex>`, `gs://bucket/key`, `ipfs://<cid>`. |
+| `dim` | Vector dimensionality | |
+| `rotation_seed` | Hadamard rotation seed | `u32`; pinned because it changes how vectors are pre-projected. |
+| `rerank_factor` | Per-shard re-rank multiplier | Float; affects recall-vs-latency. |
+| `generation` | Either `Num(u64)` or `Opaque(<bytes>)` | Numeric for monotonic stores (mtime, GCS gen); opaque for content-addressed. |
+| `pii_policy` | e.g. `class:public`, `class:internal` | Surfaced to MCP policy hooks. |
+| `lineage_id` | Stable id for the vector lineage | Unchanged across re-publish if the source pipeline is the same. |
+| `memory_class` | `durable`, `genomic`, `quantum`, ... | Substrates use this to tag their bundles. |
+
+The witness is a SHAKE-256 hash to 32 bytes over a deterministic
+serialisation of all the above plus the `format_version` tag byte. It is
+the load-bearing contract: identical bundle inputs ⇒ identical witness ⇒
+identical query results.
+
+## Reading the screen
+
+### Header strip
+
+Breadcrumb shows `rulake://bundle / <backend> / <collection>`. The header
+has three buttons:
+
+- **Pinned** — open the saved-bundles modal.
+- **Pin witness** — save the current `(backend, collection, generation,
+  witness)` tuple to IndexedDB. Useful as an immutable handle to compare
+  against later.
+- **Recompute witness** — runs `rulake-wasm`'s `computeWitness(...)`
+  in-browser, then sets `verified` based on whether the result matches the
+  server-reported value. The audit tail gains `WITNESS_MATCH`,
+  `WITNESS_MISMATCH`, or `WITNESS_COMPUTE_ERROR`.
+
+### IPFS fetch strip
+
+Below the header sits a paste-a-CID strip. Workflow:
+
+1. Paste an IPFS CID (e.g. `bafy…`).
+2. Click **Fetch from gateway**.
+3. The Console fetches the bundle JSON from the configured public gateway
+   (default `https://ipfs.io/ipfs/<cid>`).
+4. `rulake-wasm` recomputes the witness over the fetched bytes.
+5. The audit tail gains `IPFS_BUNDLE_VERIFIED` or `IPFS_WITNESS_MISMATCH`.
+
+This is the smallest end-to-end demonstration of the cross-process trust
+chain: the bytes came from an untrusted network, your browser hashed them,
+and you got either MATCH or MISMATCH locally without trusting the gateway.
+
+### Field table
+
+The middle of the page renders the bundle JSON as a key/value table, one
+row per field listed above. Click any value to copy it.
+
+### Witness comparator
+
+Three rows, all on the same canonical hex format:
+
+- **Server** — what the cache reported.
+- **Recomputed** — what `rulake-wasm` produced from the bundle bytes.
+- **Δ** — `● BIT-EXACT MATCH` (green) or `MISMATCH` (amber).
+
+The recomputed row goes grey with `· · · computing in browser · · ·`
+during the recompute, then snaps back to the canonical hex.
+
+### Generation chain · lineage
+
+A small table of the most recent five generations of this collection:
+
+| Column | Meaning |
+|---|---|
+| `Gen` | `Num(N)` or `Opaque(<hex>)`; head row marked `← head` |
+| `Issued` | UTC timestamp |
+| `Δ entries` | Net entries added/removed since the previous gen |
+| `Witness` | First 16 hex of the SHAKE-256 |
+| `Verified` | Always `●` (green) if it was successfully verified at publish time |
+
+This is the audit chain operators care about: a generation is published,
+its witness is checkpointed, and the chain is the immutable record of
+"what bytes did this collection have, and when".
+
+### Bundle receipt (right pane)
+
+The receipt on the right is a printable summary — `format`, `dim`, `gen`,
+`entries`, `pii`, then a divider, then `rotation`, `rerank`, `class`. The
+big stamp at the bottom is `✓ MATCH` (green) when verified, `VERIFYING`
+(grey) during recompute. The witness footer prints the full 64-hex.
+
+## Verifying a bundle outside the Console
+
+The same recompute path is one function call from anywhere
+`rulake-wasm` runs:
+
+```js
+import init, { computeWitness } from 'rulake-wasm';
+await init();
+
+const witness = computeWitness(
+  'rvf://seg/0x11/9ad...e72',  // data_ref
+  1024,                         // dim
+  0xa17c,                       // rotation_seed
+  1.5,                          // rerank_factor
+  { Num: 7741 },                // generation
+);
+// witness is a 64-char hex string. Compare to the server-reported value.
+```
+
+From Rust, the same is `RuLakeBundle::new(...).rvf_witness()`.
+
+## What MISMATCH actually means
+
+A mismatch is not "the data is wrong". It means *the bundle the cache is
+serving was anchored to different bytes than the descriptor says*. Three
+common causes:
+
+1. **Tampered sidecar** — somebody edited `table.rulake.json` after publish.
+2. **Schema mismatch** — the publisher used a different `format_version`,
+   or a different rotation seed/rerank factor than what the server
+   advertised.
+3. **CID-substitution** — for IPFS bundles, the bundle was re-pinned under
+   a different CID. `IpfsBackend::fetch_bundle` hard-refuses this with
+   `IPFS_BUNDLE_CID_MISMATCH` (see CHANGELOG R-IPFS-1).
+
+In all three cases the right move is to refuse, audit, and surface the
+collection's `(backend, collection)` to the operator. The Console does the
+first two automatically.

--- a/docs/userguide/07-playground.md
+++ b/docs/userguide/07-playground.md
@@ -1,0 +1,136 @@
+# 07 — Playground
+
+The Playground is the screen where you actually issue queries. It builds
+a `tools/call rulake_query` envelope, dispatches it (live wire or
+WASM-local), and renders the response with a side-panel decision trace
+and a printable witness receipt.
+
+![Playground screen — query box, k/risk/target controls on the left, hit table and decision trace on the right](../../assets/console-playground.png)
+
+## The form
+
+Left pane, top to bottom:
+
+- **Query · semantic** — free-text input. Embedded with
+  `text-embedding-3-small` at request time into a 1024-d vector if you
+  configured a key in the [Connect](./04-connect.md) screen's Storage
+  card. Otherwise embedded with a deterministic fixture vector (so the
+  recall results are stable but not semantically meaningful).
+- **Target** — pick one collection or `federated · prod+eu`. The
+  federated option tells the planner to fan out across both backends and
+  merge results. The list is hard-coded in demo mode; in live mode it
+  reflects whatever `rulake_list_collections` returned.
+- **k (results)** — top-K count. Default 10. Honoured at the cache layer.
+- **Risk** — `low` / `medium` / `high`. Surfaced to policy hooks; the
+  default Cloud Run deploy treats all three as `read`-permitted, but a
+  policy-hook-fronted server can refuse `high` from anonymous principals.
+
+## Sending a query
+
+Click **▶ Send** or press `⌘↵` (mac) / `Ctrl+Enter` (win/linux) with the
+focus inside the textarea. The Send button stays disabled while a query
+is in flight.
+
+What runs end-to-end on Send:
+
+1. **Embed the query** — provider call if configured, deterministic
+   fixture otherwise. Time recorded as `embed:Nms`.
+2. **Fan out the search** — `rulake-wasm`'s `searchL2(...)` runs the
+   actual top-K against an in-browser fixture corpus, *or* the offload
+   path runs in a Web Worker if Workers are enabled in Storage settings.
+   Time recorded as `search:Nms (transport)`.
+3. **Recompute the witness** — `rulake-wasm`'s `computeWitness(...)` runs
+   over the response provenance. Time recorded as `witness:Nms`.
+4. **Audit row** — the audit tail gains `OK_VERIFIED_<TRANSPORT>` or
+   `WITNESS_MISMATCH_REFUSED`.
+
+Top-right of the response section shows `● WITNESS MATCH` (green) or
+`MISMATCH` (amber); the printed receipt on the right pane stamps either
+`✓ MATCH` or `VERIFYING`.
+
+## Reading the response
+
+### Hits table
+
+Five columns: rank, score, id, snippet, date. Score is the cosine-or-L2
+similarity in `[0, 1]`; the green bar in the score cell is normalised
+against the top hit. ID rendering is monospace cyan to make
+copy-paste-into-grep painless.
+
+### Decision trace (right pane)
+
+Below the witness receipt is a `decision_trace` block. The named pieces:
+
+- **`reason_code`** — concise reason the planner picked the path it did.
+  The most common is `CACHE_HIT_FRESH` (cache was warm and the consistency
+  check passed). Refusal codes are the same set surfaced on the
+  [Stats](./02-stats-screen.md) screen.
+- **`chosen_action`** — `serve_from_cache`, `prime_from_backend`,
+  `serve_from_pinned`, `refuse`.
+- **`budget`** — `used_ms / max_ms`. Crossing `max_ms` always refuses
+  with `BUDGET_EXCEEDED`.
+- **`backends_used`** — one row per backend touched, with per-backend
+  latency and hit count. For a single-target query this is one row; for a
+  federated query it is two or more.
+- **`refusals`** — any backend the planner declined to consult, and why.
+  In the example shipped with the fixture this is
+  `lake-eu/memories STALE_BUNDLE_GUARD — Cached witness is 1 generation
+  behind freshness budget (1500ms)`.
+
+### Witness receipt
+
+Top-right of the right pane: `RULAKE · WITNESS · SHAKE-256 · 32 bytes`,
+the bundle name, the issued-at, the trust level, and the full 64-hex.
+Click anywhere on the hex to copy.
+
+## Consistency modes
+
+The cache layer exposes three consistency modes (see
+`crates/core/src/cache.rs:55`). The Playground does not surface them
+explicitly — they are configured server-side per `RuLake` instance — but
+every refusal you see on this screen ties back to which one is in force.
+
+| Mode | Behaviour | Use case |
+|---|---|---|
+| **`Fresh`** (default) | Consult the backend's current bundle on every search. | Compliance, finance, policy-enforced workloads where any stale answer is worse than a slower answer. |
+| **`Eventual { ttl_ms }`** | Trust the cache for up to `ttl_ms` between checks. Higher QPS; backend updates may be ignored for up to `ttl_ms`. | Search, RAG, recommendation — where a small staleness window is a trade every customer accepts. |
+| **`Frozen`** | Caller asserts the bundle is immutable for the cache's lifetime. Never re-check the backend, never invalidate on generation bump. | Witness-sealed historical snapshots. The audit tier. An explicit `refresh_from_bundle_dir` call still invalidates; the guarantee is about automatic checks. |
+
+A `STALE_BUNDLE_GUARD` refusal under `Fresh` becomes `STALE_BUNDLE_FALLBACK`
+(degraded, not refused) under `Eventual`. Under `Frozen` neither code can
+fire — the cache will not even check.
+
+## Saving and loading queries
+
+- **Save** opens a modal that writes `{label, query, k, risk, target}` to
+  IndexedDB. Saved queries are local to the browser.
+- **Load** opens a modal listing every saved query; pick one and the form
+  populates. The audit tail does not record loads.
+
+## Wire payload
+
+The bottom-right of the right pane shows the exact JSON envelope the
+Console will send on the next Send, with the current `k` and `risk`
+substituted. Useful when you need to reproduce a Playground query from a
+shell:
+
+```bash
+curl -fsS -X POST https://rulake-mcp.ruv.io/ \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'mcp-session-id: <session>' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 9,
+    "method": "tools/call",
+    "params": {
+      "name": "rulake_query",
+      "arguments": {
+        "intent": "search",
+        "target": { "collection": "memories" },
+        "search": { "k": 10 },
+        "risk": "medium"
+      }
+    }
+  }'
+```

--- a/docs/userguide/08-audit-ledger.md
+++ b/docs/userguide/08-audit-ledger.md
@@ -1,0 +1,164 @@
+# 08 — Audit ledger
+
+The Audit screen is a live tail of every MCP call the Console (or the
+connected MCP) has emitted. It is the single source of truth for "what
+happened, and was it allowed". Rows are JSONL, append-only, locally
+persisted in IndexedDB, and survive page reloads.
+
+![Audit screen — JSONL tape with timestamp, principal, tool, target, result code colour-coded by outcome](../../assets/console-audit.png)
+
+## Where rows come from
+
+The tail mixes two streams:
+
+1. **Local rows** — every Console action that touches the wire (Connect,
+   Browse refresh, Bundle recompute, Playground send) appends a row via
+   `RuStore.appendAudit({...})`. These rows carry a small green `●` next
+   to their timestamp to mark them as locally-generated.
+2. **Fixture rows** — a static set of demo entries from
+   `ui/src/lib/data.js` `AUDIT`. These exist so the tape reads usefully
+   in DEMO mode.
+
+Server-side `mcp-server` also keeps its own audit ledger (see
+`crates/mcp-server/src/audit.rs`) and the v0.6 ADR-005 work added
+symmetric audit shape across read and mutation tools (see CHANGELOG R-MCP-1).
+That ledger is not surfaced into the browser tail today; it is exposed via
+the `rulake_audit_tail` admin tool and via structured tracing.
+
+## Filtering by env
+
+The audit row carries a `target` field shaped `<backend>/<collection>`.
+The screen filters this against whichever environment tab is active in
+the topbar:
+
+- `lake-prod` shows rows with target prefix `lake-prod/`
+- `lake-eu` shows rows with target prefix `lake-eu/`
+- `lake-edge` shows rows with target prefix `lake-edge/`
+
+Local rows always show regardless of env (they typically target an
+endpoint URL, not a backend id).
+
+## Filtering by outcome
+
+The right side of the header has a four-state segmented control:
+
+- **all** — no outcome filter
+- **ok** — only `outcome === "ok"`
+- **degraded** — only `outcome === "degraded"`
+- **refused** — only `outcome === "refused"`
+
+The shapes line up with `crates/mcp-server/src/audit.rs::AuditEntry`:
+
+```rust
+pub struct AuditEntry {
+    pub ts: u64,
+    pub principal: String,
+    pub tool: String,
+    pub target: String,
+    pub k: u64,
+    pub ms: u64,
+    pub code: String,
+    pub outcome: String,  // "ok" | "refused" | "degraded" | "error"
+}
+```
+
+## Reading a row
+
+```
+13:41:08.812  agent-7f       query                   lake-prod/memories  · k=10  · 11ms   OK
+13:41:06.991  agent-7f       query                   lake-eu/memories    · k=10  · 28ms   STALE_BUNDLE_FALLBACK
+13:41:06.044  agent-q2       query                   lake-prod/docs.public · k=10 · 4ms   WITNESS_MISMATCH_REFUSED
+13:41:04.840  jules@ruv      warm_from_dir           lake-prod/tickets.support · k=- · 1820ms  OK
+13:41:04.011  agent-q2       query                   lake-edge/changelog · k=5   · 2ms    POLICY_DENIED
+```
+
+Left to right: timestamp, principal, tool name (with the `rulake_` prefix
+elided), target, k+ms summary, code. The whole row is colour-coded by
+outcome:
+
+- green text = `ok`
+- amber text = `degraded`
+- amber-red text = `refused`
+
+## Event types you will see
+
+This list is not exhaustive (substrates and policy hooks can emit their
+own codes), but covers the common surface:
+
+### Read path
+- **`OK`** — successful query, witness matched, response served from
+  cache or after a prime.
+- **`OK_VERIFIED_MAIN`** / **`OK_VERIFIED_WORKER`** — Playground emits
+  these to indicate which transport ran the search.
+- **`STALE_BUNDLE_FALLBACK`** — `Eventual` consistency mode allowed a
+  degraded response when the cache was past TTL.
+- **`STALE_BUNDLE_GUARD`** — `Fresh` consistency refused the same
+  condition.
+- **`WITNESS_MISMATCH_REFUSED`** — server-reported witness disagreed with
+  the recompute. Always-refuse.
+- **`POLICY_DENIED`** — JWT scope, `pii_policy`, or risk class rejected.
+- **`BUDGET_EXCEEDED`** — exceeded `budget.max_latency_ms`.
+
+### Mutation path
+- **`PUBLISH_QUEUED`** — `rulake_publish_bundle` accepted; new generation
+  is being computed.
+- **`OK`** for `publish_bundle` / `refresh_from_bundle_dir` /
+  `invalidate_cache` / `save_cache_to_dir` / `warm_from_dir` —
+  mutation succeeded. Audit shape is symmetric with reads as of v0.6.
+
+### Browse / list
+- **`LIST_COLLECTIONS_OK`** — refresh succeeded; row carries `k=<count>`
+  of collections discovered.
+- **`LIST_COLLECTIONS_FAILED`** — refresh failed; the message is a
+  trimmed exception string.
+
+### Connect path
+- **`SAVED_LOCAL`** — endpoint persisted to IndexedDB.
+- **`INIT_OK`** — MCP `initialize + notifications/initialized + tools/list`
+  all succeeded; row carries the discovered tool count.
+- **`CONNECT_FAILED`** — handshake failed. Causes range from CORS preflight
+  rejection to TLS to 401. See [10 — Troubleshooting](./10-troubleshooting.md).
+
+### Bundle / witness path
+- **`WITNESS_MATCH`** — recompute agreed.
+- **`WITNESS_MISMATCH`** — recompute disagreed.
+- **`WITNESS_COMPUTE_ERROR`** — `rulake-wasm` raised before producing a
+  hash. Almost always indicates a malformed bundle.
+
+### IPFS path
+- **`IPFS_BUNDLE_VERIFIED`** — fetched bytes hashed to the expected witness.
+- **`IPFS_WITNESS_MISMATCH`** — hashed but disagreed (CID-substitution).
+- **`IPFS_FETCH_FAILED`** — gateway returned non-2xx.
+- **`IPFS_NETWORK_ERROR`** — fetch threw before a response.
+- **`IPFS_OK`** / **`IPFS_HTTP_ERROR`** — used by the Bundle screen's
+  raw-fetch debug strip.
+
+## Clearing local rows
+
+The **Clear local** button in the header removes every locally-generated
+row from IndexedDB. Fixture rows are not touched (they live in JS, not
+IndexedDB). The button is disabled when there are no local rows.
+
+## Exporting
+
+Open devtools `Application > Storage > IndexedDB > rulake-store > audit`
+to export rows. Each row is the same `AuditEntry` shape as the server
+emits, so it round-trips cleanly into any JSONL pipeline.
+
+## When the audit tail saves you
+
+A few realistic scenarios:
+
+- A query returns nothing. Check the audit row for the same `ts` — was it
+  `WITNESS_MISMATCH_REFUSED` (the cache lied) or `BUDGET_EXCEEDED` (you
+  asked for too much in too little time)?
+- The Console shows `○ DEMO` after you clicked Connect. Look for
+  `CONNECT_FAILED` — the message field has the actual error. CORS gives
+  one shape, 401 another, TLS another.
+- A Browse refresh comes back empty. `LIST_COLLECTIONS_OK k=0` means the
+  server has no backends registered (probably a configuration gap).
+  `LIST_COLLECTIONS_FAILED` means the call itself failed — the message has
+  the cause.
+
+The audit ledger is the first place to look when something on a more
+visual screen does not match expectations.

--- a/docs/userguide/09-live-mcp-setup.md
+++ b/docs/userguide/09-live-mcp-setup.md
@@ -1,0 +1,118 @@
+# 09 — Live MCP setup
+
+If you want the Console to drive your own server instead of the hosted
+demo at `rulake-mcp.ruv.io`, this page is the three-minute summary. The
+full recipe — every gotcha, every commit reference — lives in
+[`docs/deploy/cloud-run.md`](../deploy/cloud-run.md).
+
+## The shortest possible flow
+
+The hosted demo runs the `mcp-server` binary in distroless on Cloud Run,
+fronted by a Cloudflare CNAME for the `rulake-mcp.ruv.io` hostname. To
+reproduce against your own GCP project:
+
+```bash
+# 1. Build and push the image (~3 min on E2_HIGHCPU_8)
+gcloud builds submit . --project=YOUR-PROJECT --region=us-central1 \
+  --config=deploy/cloudbuild-mcp.yaml
+
+# 2. Deploy to Cloud Run with the right capability and binding flags
+gcloud run deploy rulake-mcp-demo \
+  --image=us-central1-docker.pkg.dev/YOUR-PROJECT/cloud-run-source-deploy/rulake-mcp-demo:latest \
+  --region=us-central1 --project=YOUR-PROJECT \
+  --allow-unauthenticated --port=8080 \
+  --memory=512Mi --cpu=1 --min-instances=1 --max-instances=1 \
+  --timeout=60s \
+  --set-env-vars="RUST_LOG=info" \
+  --command=/usr/local/bin/rulake-mcp \
+  --args="^|^http|--bind|0.0.0.0:8080|--auth|none|--insecure-allow-no-auth|--capabilities|read,publish,admin"
+
+# 3. Tell rmcp's Host guard about your user-facing hostname(s)
+gcloud run services update rulake-mcp-demo \
+  --region=us-central1 --project=YOUR-PROJECT \
+  --update-env-vars="^|^RULAKE_ALLOWED_HOSTS=rulake-mcp-demo-NUMBERS.us-central1.run.app,your-host.example"
+
+# 4. Smoke-test the wire end-to-end (TLS + CORS + MCP handshake + tools/list)
+URL=https://your-host.example/ ./scripts/smoke-live.sh
+```
+
+That is the whole flow. If `smoke-live.sh` exits 0 with `tools/list
+returned 8 tools`, you are ready to point the Console at it from the
+[Connect screen](./04-connect.md).
+
+## What every flag is doing
+
+| Flag | Why it matters |
+|---|---|
+| `--min-instances=1 --max-instances=1` | rmcp's `LocalSessionManager` is process-local. Sessions don't survive failover; pin to one warm instance for the demo wire. |
+| `--port=8080` + hardcoded `--bind 0.0.0.0:8080` | Cloud Run sets `$PORT` dynamically, but distroless has no shell to interpolate. 8080 is Cloud Run's default when `--port` isn't set, so hard-coding both sides works. |
+| `--auth none --insecure-allow-no-auth` | Demo / read-only. Production replaces this with JWT or mTLS — same infra, different two flags. |
+| `--capabilities read,publish,admin` | The 8-tool surface. Without this, mcp-server defaults to read-only (3 tools) and the Console will report `3 tools` instead of `8`. |
+| `^|^` arg delimiter | The default delimiter for `--args` is comma, but the capability list itself contains commas. `^|^` tells gcloud to split on `\|` instead. |
+| `RULAKE_ALLOWED_HOSTS=...` | rmcp's DNS-rebinding guard rejects unknown `Host` headers with 403. Put every user-facing hostname in here. Also enables a stable principal so sessions survive Cloud Run's per-request internal-IP rotation. |
+
+## What needs a custom domain
+
+Nothing, strictly. The Cloud Run-generated URL
+(`rulake-mcp-demo-NUMBERS.us-central1.run.app/`) works fine. The custom
+domain is purely cosmetic. If you skip the CNAME / domain mapping
+(steps 5a–5c in the deploy doc), you only need to set the Console's
+default endpoint — see step 7 in the deploy doc.
+
+## Smoke-testing without GCP
+
+If you just want to know whether your MCP is wire-compatible with the
+Console, point the smoke script at it:
+
+```bash
+URL=https://your-mcp.example/ ./scripts/smoke-live.sh
+```
+
+The script makes 11 assertions in ~3 seconds, no Chrome required:
+
+1. TLS handshake completes
+2. CORS preflight `OPTIONS` returns 204
+3. Preflight carries `access-control-allow-origin` for `https://ruvnet.github.io`
+4. Preflight carries `access-control-allow-methods`
+5. Preflight carries `access-control-allow-headers`
+6. Preflight exposes `mcp-session-id`
+7. `initialize` returns 200 with an `mcp-session-id` header
+8. `notifications/initialized` returns 200 or 202
+9. `tools/list` returns at least one SSE `data:` line with a JSON envelope
+10. The envelope's `result.tools` length matches `EXPECTED_TOOLS` (default 8)
+11. Exit 0 if every assertion passed
+
+If any assertion fails the script prints the failed one in red and exits 1.
+This is the same shape the CI workflow runs on every PR.
+
+## Pointing the Console at your server
+
+Two paths:
+
+1. **Per-session** — open the Console, go to [Connect](./04-connect.md),
+   paste your endpoint URL, click **Connect & initialize**. The pill in
+   the topbar flips to `● LIVE · <your host>`. Save the endpoint to keep
+   it across sessions.
+2. **Permanent** — fork the repo, edit
+   `ui/src/components/screens.jsx` `ConnectScreen` `setEndpoint` default
+   value, rebuild and redeploy the Console. Both the boot probe and the
+   Connect form will use the new default. The release-ui workflow handles
+   the GitHub Pages publish.
+
+## Cost ballpark
+
+Cloud Run free tier covers 2M requests / 360k GB-s / 180k CPU-s per month.
+For the demo's `min=1 max=1 512Mi 1cpu` profile:
+
+- Idle: ~$5/mo for the always-warm instance.
+- Per request: free up to the 2M ceiling.
+
+If you can tolerate a 2-3 second cold start every time the Console loads,
+drop to `min=0` and the cost drops to ~$0. The session-stickiness caveat
+still applies — every cold start drops every in-flight session.
+
+## Full recipe
+
+For everything else — `.gcloudignore` config, BuildKit gotchas, Cloudflare
+CNAME, Let's Encrypt cert provisioning, the iteration history that produced
+this recipe — see [`docs/deploy/cloud-run.md`](../deploy/cloud-run.md).

--- a/docs/userguide/10-troubleshooting.md
+++ b/docs/userguide/10-troubleshooting.md
@@ -1,0 +1,186 @@
+# 10 — Troubleshooting
+
+The Console is mostly self-explanatory, but four classes of failure are
+common enough to deserve a checklist. Each entry below names the
+symptom you will see, the root cause, and the smallest fix that closes it.
+
+For any failure: open the [Audit ledger](./08-audit-ledger.md) first. The
+specific code (`CONNECT_FAILED`, `LIST_COLLECTIONS_FAILED`,
+`WITNESS_MISMATCH_REFUSED`) and the message field tell you which of the
+sections below applies.
+
+## TLS handshake failed
+
+**Symptom.** `smoke-live.sh` exits red on the very first assertion:
+`TLS handshake failed against <URL>`. Or a Connect attempt produces a
+`CONNECT_FAILED` audit row whose message contains `Failed to fetch` or
+`net::ERR_CERT_*`.
+
+**Cause.** Most often the Cloudflare CNAME for the custom domain has
+`proxied: true` (orange cloud), which prevents Cloud Run's domain mapping
+from completing the `01-challenge` and provisioning the Let's Encrypt cert.
+Less often: the cert is still provisioning (5–15 min after CNAME
+resolves), or the cert has expired.
+
+**Fix.**
+
+1. Confirm the CNAME is `proxied: false`:
+   ```bash
+   curl -sI https://your-host.example/ | head -1
+   # Expect HTTP/2 200 or 405; if you see Cloudflare's challenge page or
+   # a 525, proxying is on.
+   ```
+2. If you just provisioned, wait. Track the cert state:
+   ```bash
+   gcloud beta run domain-mappings describe \
+     --domain=your-host.example \
+     --region=us-central1 --project=YOUR-PROJECT \
+     --format='value(status.conditions[].type:label=cond,status.conditions[].status:label=stat)'
+   # Wait until CertificateProvisioned=True
+   ```
+3. If proxying is on by policy, you can keep it on but only after the
+   cert is live. Cloud Run is already terminating TLS, so there is little
+   to gain from also letting Cloudflare terminate.
+
+## Topbar pill stays at `○ DEMO`
+
+**Symptom.** You opened the Console, the boot probe should have flipped
+to `● LIVE`, but the pill is still grey. Or you clicked Connect and got
+a green status line — but the pill never updated.
+
+**Cause.** Three common ones:
+
+1. The boot probe ran, but `https://rulake-mcp.ruv.io/` is unreachable
+   from your network (corporate VPN, geo-block, gateway down).
+2. The probe succeeded but a downstream JS error swallowed the
+   `rulake:live-connected` event before the topbar listener fired.
+3. The endpoint you typed in the Connect screen does not include the
+   trailing slash. `mcp-server` mounts on `/`; some reverse proxies do
+   strict path matching and 404 the no-slash form.
+
+**Fix.**
+
+1. Sanity-check the wire from your machine:
+   ```bash
+   curl -sI https://rulake-mcp.ruv.io/
+   # Expect HTTP/2 405 (it accepts only POST). Any other status is a
+   # network problem, not an MCP problem.
+   ```
+2. Open devtools. The Connect handler logs every step; a `RuLakeHttp`
+   exception will be visible there even if the toast slid past you.
+3. Always include the trailing slash in the endpoint. The default
+   `https://rulake-mcp.ruv.io/` is correct; `https://rulake-mcp.ruv.io`
+   may not be.
+
+## CORS preflight rejected
+
+**Symptom.** The Connect attempt produces `CONNECT_FAILED` with a message
+containing `Failed to fetch`. The browser console shows a CORS error
+explaining that the preflight `OPTIONS /` did not return the expected
+headers.
+
+**Cause.** The MCP server is missing CORS support, or its CORS layer is
+allow-listed to a different Origin than `https://ruvnet.github.io` (or
+whichever origin you are loading the Console from).
+
+**Fix.**
+
+1. Confirm preflight directly:
+   ```bash
+   curl -isS -X OPTIONS https://your-mcp.example/ \
+     -H 'Origin: https://ruvnet.github.io' \
+     -H 'Access-Control-Request-Method: POST' \
+     -H 'Access-Control-Request-Headers: content-type, mcp-session-id' \
+     | head -10
+   # Expect HTTP/2 204 with access-control-allow-* headers.
+   ```
+2. The reference implementation is `crates/mcp-server/src/http.rs:287+`.
+   If you wrote your own server, port that pattern: echo the requesting
+   `Origin`, expose `mcp-session-id` and `mcp-protocol-version`, and
+   short-circuit `OPTIONS` with 204.
+3. If the server is fronted by a reverse proxy, make sure the proxy
+   does not strip `Access-Control-*` headers on its way back.
+
+This is the same bug class that hit `mcp-rvdna` v0.0.1 and was fixed in
+iter 32 — the symptom in the wild was `Failed to fetch` on `OPTIONS /mcp`.
+
+## Session 401 / sessions drop mid-conversation
+
+**Symptom.** `initialize` succeeds (you get a session id back), but the
+next call — `tools/list`, `tools/call`, anything — returns 401 with a
+message about an unknown session. Or sessions work for a few minutes then
+start failing.
+
+**Cause.** rmcp's `LocalSessionManager` keeps sessions in process-local
+memory. Two failure modes:
+
+1. **`max-instances > 1`** — the second call lands on a different Cloud
+   Run instance which has no record of the session.
+2. **Per-request peer-IP rotation** — Cloud Run's frontend rotates the
+   internal source IP between requests. Without
+   `RULAKE_ALLOWED_HOSTS` set, mcp-server keys principals on
+   `anon:{peer}`, which changes between requests, which invalidates the
+   session.
+
+**Fix.**
+
+1. Pin the service to one instance:
+   ```bash
+   gcloud run services update rulake-mcp-demo \
+     --region=us-central1 --project=YOUR-PROJECT \
+     --min-instances=1 --max-instances=1
+   ```
+2. Set the allowed-hosts env var (this also enables the
+   `anon:proxied` stable principal under reverse proxies, see commit
+   `2427543`):
+   ```bash
+   gcloud run services update rulake-mcp-demo \
+     --region=us-central1 --project=YOUR-PROJECT \
+     --update-env-vars='^|^RULAKE_ALLOWED_HOSTS=your-host.example,rulake-mcp-demo-NUMBERS.us-central1.run.app'
+   ```
+
+For production with a session manager that survives failover, the right
+move is to swap `LocalSessionManager` for a Redis-backed one. That is on
+the roadmap, not shipped today.
+
+## `RULAKE_ALLOWED_HOSTS` gotcha
+
+**Symptom.** Every request, including `initialize`, returns 403. The
+server logs include a tracing entry rejecting the `Host` header with
+"DNS rebinding guard".
+
+**Cause.** rmcp's Streamable HTTP transport rejects unknown `Host` values
+with 403 by default. Cloud Run's frontend forwards the user-facing
+hostname (e.g. `rulake-mcp.ruv.io`), not the internal `0.0.0.0:8080` the
+container thinks it is bound to. Without an allow-list, every request
+from the public internet 403s.
+
+**Fix.** Set `RULAKE_ALLOWED_HOSTS` to a comma-separated list of every
+hostname operators will use. This must include both the Cloud Run-generated
+host and any custom domain CNAME'd in front of it:
+
+```bash
+gcloud run services update rulake-mcp-demo \
+  --region=us-central1 --project=YOUR-PROJECT \
+  --update-env-vars='^|^RULAKE_ALLOWED_HOSTS=rulake-mcp.ruv.io,rulake-mcp-demo-iru57wnnaq-uc.a.run.app'
+```
+
+The `^|^` delimiter is required because the env value contains a comma —
+this is gcloud's escape syntax for delimiter-bearing values.
+
+The reverse-proxy fix (commit `4248b75`) and the stable-principal fix
+(`2427543`) both ride on the same env var. Setting it correctly fixes
+both classes of failure simultaneously.
+
+## When all else fails
+
+- **Run the smoke script.** `URL=https://your-mcp.example/ scripts/smoke-live.sh`
+  walks the entire wire and tells you exactly which assertion failed.
+- **Check the audit tail.** Every Console action that touches the wire
+  emits a row with the failing code and message in plain text.
+- **Read the deploy doc.** `docs/deploy/cloud-run.md` documents every
+  gotcha encountered while bringing up the live demo, with commit
+  references.
+- **Check `CHANGELOG.md`.** The "Iteration history" tables there call
+  out commits that fixed each class of regression. Searching the
+  changelog for your symptom is often faster than re-deriving the fix.

--- a/docs/userguide/README.md
+++ b/docs/userguide/README.md
@@ -1,0 +1,43 @@
+# ruLake Console — User Guide
+
+ruLake is a cache-coherent vector federation intermediary built on RVF (Reified
+Vector Format). It sits between your existing vector stores (GCS Parquet, IPFS,
+local files, custom adapters) and AI agents speaking MCP, returning
+trust-anchored bundles whose contents are pinned by a SHAKE-256(32) witness
+hash. The Console is a static React SPA that exercises the wire end-to-end
+against a hosted MCP at [`https://rulake-mcp.ruv.io/`](https://rulake-mcp.ruv.io/),
+auto-flipping from `○ DEMO` to `● LIVE` once the probe lands. This guide walks
+through every screen, the tools the Console drives, and the operational knobs
+that matter when you point it at your own server.
+
+## Pages
+
+| # | Page | What it covers |
+|---|---|---|
+| 01 | [Getting started](./01-getting-started.md) | Open the live console, what auto-probes on boot, keyboard shortcuts |
+| 02 | [Stats screen](./02-stats-screen.md) | Hits / misses / hit-rate / primes / refusals / verified counts |
+| 03 | [App store](./03-app-store.md) | Substrate catalog, `SHIPPING` vs `SCAFFOLDED` tags, install commands |
+| 04 | [Connect](./04-connect.md) | Endpoint, auth modes, what the topbar `LIVE` pill means |
+| 05 | [Backends and collections](./05-backends-and-collections.md) | Browse backends, `BackendAdapter` trait, federation graph |
+| 06 | [Bundle / witness viewer](./06-bundle-witness-viewer.md) | Fields of a `table.rulake.json` sidecar, browser-side recompute |
+| 07 | [Playground](./07-playground.md) | Issuing `rulake_query`, k / risk / target, decision trace |
+| 08 | [Audit ledger](./08-audit-ledger.md) | Event types, outcome filters, where rows come from |
+| 09 | [Live MCP setup](./09-live-mcp-setup.md) | Three-minute summary; defers to the Cloud Run deploy doc |
+| 10 | [Troubleshooting](./10-troubleshooting.md) | TLS, DEMO-stuck, CORS, 401, `RULAKE_ALLOWED_HOSTS` |
+
+## Quick links
+
+- Hosted Console: <https://ruvnet.github.io/RuLake/>
+- Hosted MCP: <https://rulake-mcp.ruv.io/>
+- Repository: <https://github.com/ruvnet/RuLake>
+- Cloud Run deploy recipe: [`docs/deploy/cloud-run.md`](../deploy/cloud-run.md)
+- Live-wire smoke test: [`scripts/smoke-live.sh`](../../scripts/smoke-live.sh)
+
+## Conventions used in this guide
+
+- Shell snippets assume bash and a recent `curl`. They run unchanged against
+  the public MCP at `https://rulake-mcp.ruv.io/`.
+- Cargo / npm install lines reference real published crates and packages
+  (`rulake` on crates.io, `rulake-wasm` on npm).
+- "the Console" refers to the SPA at `https://ruvnet.github.io/RuLake/`.
+  "the MCP" refers to whichever `rulake-mcp` server it is currently pointed at.

--- a/sdk/node-wasm/.gitignore
+++ b/sdk/node-wasm/.gitignore
@@ -1,0 +1,11 @@
+target/
+node_modules/
+*.log
+*.tgz
+
+# wasm-pack outputs — recreated by ./build.sh, published via .npmignore overrides.
+web/
+nodejs/
+pkg-bundler/
+pkg-web/
+pkg-nodejs/

--- a/sdk/node-wasm/.npmignore
+++ b/sdk/node-wasm/.npmignore
@@ -6,3 +6,15 @@ build.sh
 Cargo.toml
 Cargo.lock
 .gitignore
+pkg-bundler/
+pkg-web/
+pkg-nodejs/
+
+# wasm-pack writes web/.gitignore and nodejs/.gitignore with `**`,
+# which npm honors via gitignore semantics even when an .npmignore exists.
+# These two negations re-include the build outputs that the package.json
+# `files` field and the `exports` map both depend on.
+!web/
+!web/**
+!nodejs/
+!nodejs/**

--- a/sdk/node-wasm/build.sh
+++ b/sdk/node-wasm/build.sh
@@ -62,3 +62,11 @@ if command -v wasm-opt >/dev/null 2>&1; then
 else
     echo "==> wasm-opt not installed — skipping (install binaryen for ~30% size win)"
 fi
+
+# wasm-pack writes a `.gitignore: **` into every --out-dir. npm honors
+# that nested ignore even when the root `.npmignore` re-includes the
+# directory, which silently strips web/ and nodejs/ from the published
+# tarball — the very paths the package.json `exports` map points at.
+# Removing them here keeps `npm publish` honest.
+echo "==> strip wasm-pack-generated .gitignore files (so npm publish includes web/+nodejs/)"
+rm -f web/.gitignore nodejs/.gitignore pkg-bundler/.gitignore

--- a/ui/scripts/smoke-cross-mcp.sh
+++ b/ui/scripts/smoke-cross-mcp.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 
 UI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_DIR="$(cd "${UI_DIR}/.." && pwd)"
-RVDNA_DIR="${REPO_DIR}/mcp-rvdna"
+RVDNA_DIR="${REPO_DIR}/crates/mcp-rvdna"
 
 PREVIEW_PORT=4173
 RVDNA_PORT=17441


### PR DESCRIPTION
## Summary

Two commits on top of merged PR #13 (the crates/ + sdk/ reorg):

1. **`7f8556d` — publish rulake-wasm@2.3.0-alpha.1 + ship docs/userguide**
   - Fixed `sdk/node-wasm/.npmignore` to override wasm-pack's auto-generated `web/.gitignore` + `nodejs/.gitignore` (`**`), which were silently stripping exactly the directories the package.json `exports` map points at.
   - `build.sh` now removes those nested `.gitignore` files post-build so re-publish stays correct.
   - Added `sdk/node-wasm/.gitignore` so build outputs don't pollute git.
   - Result: `rulake-wasm@2.3.0-alpha.1` live on npm with all 19 files including `web/` + `nodejs/` subdirs (was 7 files previously, missing the runtime entry points).
   - User guide: 11 markdown files at `docs/userguide/` (1395 lines total) — README index + 10 numbered pages with all 7 console screenshots embedded; cross-links validated; no broken paths.

2. **`316e5f5` — docs/gists: add accelerator-plane deep gist (ADR-157, 2953 words)**
   - New gist at `docs/gists/accelerator-plane-deep.md` — closes the ADR-157 gap.
   - Walks through the `VectorKernel` trait shape, the dispatch policy in `RuLake::pick_kernel`, and the determinism filter that keeps witness-sealed paths kernel-independent.
   - Covers both shipped implementations: `crates/kernel-avx512/` (bit-equal AVX-512, runtime CPUID gate) and `crates/kernel-wgpu/` (portable GPU via wgpu, deterministic popcount, coarse L2).
   - Updated `docs/gists/README.md`: new "Accelerator-tier" section, ADR-157 dropped from without-gists list, total bumped to ~34k words / 11 gists.
   - Published publicly: <https://gist.github.com/ruvnet/a61af62e204cde0480618123c4da21e9>

## Out-of-band validation since the last merge

End-to-end smoke against all 3 MCPs running in Docker (the same `scripts/smoke-live.sh` we use against production):

| Image | Size | URL | Tools | Result |
|---|---|---|---|---|
| `rulake-mcp:e2e` | 51.5 MB | `http://localhost:7440/` | 8 | 11/11 assertions pass |
| `rvdna-mcp:e2e` | 44.0 MB | `http://localhost:7441/` | 5 | 11/11 assertions pass |
| `ruqu-mcp:e2e` | 45.4 MB | `http://localhost:7442/` | 5 | 11/11 assertions pass |

All 3 needed `RULAKE_ALLOWED_HOSTS=localhost:N,127.0.0.1:N` to flip the principal to stable `anon:proxied` — the same gotcha we documented for Cloud Run, now confirmed identical under Docker bridge networking. Deeper check: `tools/call` for `rulake_list_backends` returned `{"backends": []}` (correct — demo container has no adapters wired).

## Test plan

- [x] Local: `cd sdk/node-wasm && npm pack` includes 19 files (web/ + nodejs/ + root)
- [x] Live: `npm view rulake-wasm` returns 2.3.0-alpha.1
- [x] Docker E2E: all 3 MCP servers green
- [ ] CI: matrix build green for all crates after merge

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)