### PR TITLE
fix: security audit — clippy, correctness, cargo fmt (2026-05-23)

### DIFF
--- a/crates/core/src/bin/rulake-demo.rs
+++ b/crates/core/src/bin/rulake-demo.rs
@@ -18,8 +18,8 @@ use std::time::Instant;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Normal, Uniform};
 
-use ruvector_rabitq::{AnnIndex, RabitqPlusIndex, RandomRotationKind};
 use rulake::{cache::Consistency, LocalBackend, RuLake, SearchResult};
+use ruvector_rabitq::{AnnIndex, RabitqPlusIndex, RandomRotationKind};
 
 fn clustered(n: usize, d: usize, n_clusters: usize, seed: u64) -> Vec<Vec<f32>> {
     use rand::Rng as _;

--- a/crates/core/src/kernel.rs
+++ b/crates/core/src/kernel.rs
@@ -204,9 +204,13 @@ pub fn assert_kernel_conformant(k: &dyn VectorKernel, fixture_seed: u64) {
     let top_k = 5usize;
 
     // Tiny LCG so the fixture is reproducible without pulling rand.
-    let mut state = fixture_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    let mut state = fixture_seed
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(1);
     let mut next_u64 = || {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         state
     };
     let mut next_f32 = || {
@@ -231,7 +235,8 @@ pub fn assert_kernel_conformant(k: &dyn VectorKernel, fixture_seed: u64) {
     let got_l2 = k.l2_distance_one(&query_f, &candidates_f, top_k);
     let want_l2 = reference.l2_distance_one(&query_f, &candidates_f, top_k);
     assert_eq!(
-        got_l2, want_l2,
+        got_l2,
+        want_l2,
         "kernel {:?} l2_distance_one diverges from CpuNaiveKernel reference",
         k.id()
     );
@@ -239,7 +244,8 @@ pub fn assert_kernel_conformant(k: &dyn VectorKernel, fixture_seed: u64) {
     let got_pc = k.rabitq_popcount(&query_u, &candidates_u, top_k);
     let want_pc = reference.rabitq_popcount(&query_u, &candidates_u, top_k);
     assert_eq!(
-        got_pc, want_pc,
+        got_pc,
+        want_pc,
         "kernel {:?} rabitq_popcount diverges from CpuNaiveKernel reference",
         k.id()
     );

--- a/crates/core/src/lake.rs
+++ b/crates/core/src/lake.rs
@@ -110,7 +110,10 @@ impl RuLake {
     /// Delegates to `BackendAdapter::list_collections`. Backed by
     /// the `rulake_list_collections` MCP tool (mcp-server v0.9 — closes
     /// ADR-006 server-gap #1 for the Console's Browse screen live mode).
-    pub fn list_collections(&self, id: &str) -> crate::error::Result<Vec<crate::backend::CollectionId>> {
+    pub fn list_collections(
+        &self,
+        id: &str,
+    ) -> crate::error::Result<Vec<crate::backend::CollectionId>> {
         self.get_backend(id)?.list_collections()
     }
 

--- a/crates/core/tests/federation_smoke.rs
+++ b/crates/core/tests/federation_smoke.rs
@@ -18,8 +18,8 @@ use std::time::Instant;
 use rand::{Rng, SeedableRng};
 use rand_distr::{Distribution, Normal, Uniform};
 
-use ruvector_rabitq::{AnnIndex, RabitqPlusIndex};
 use rulake::{cache::Consistency, FsBackend, LocalBackend, RuLake};
+use ruvector_rabitq::{AnnIndex, RabitqPlusIndex};
 
 fn clustered(n: usize, d: usize, n_clusters: usize, seed: u64) -> Vec<Vec<f32>> {
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
@@ -357,20 +357,14 @@ fn dimension_mismatch_returns_error() {
     lake.register_backend(backend).unwrap();
     let bad_query = vec![0.0; d + 1];
     let err = lake.search_one("tiny", "c", &bad_query, 1).unwrap_err();
-    assert!(matches!(
-        err,
-        rulake::RuLakeError::DimensionMismatch { .. }
-    ));
+    assert!(matches!(err, rulake::RuLakeError::DimensionMismatch { .. }));
 }
 
 #[test]
 fn unknown_backend_returns_error() {
     let lake = RuLake::new(20, 0);
     let err = lake.search_one("nope", "nope", &[0.0; 4], 1).unwrap_err();
-    assert!(matches!(
-        err,
-        rulake::RuLakeError::UnknownBackend(_)
-    ));
+    assert!(matches!(err, rulake::RuLakeError::UnknownBackend(_)));
 }
 
 #[test]
@@ -478,10 +472,7 @@ fn unknown_collection_returns_error() {
     lake.register_backend(backend).unwrap();
     let err = lake.search_one("b", "missing", &[0.0; 4], 1).unwrap_err();
     // Error surfaces via the backend's generation() call.
-    assert!(matches!(
-        err,
-        rulake::RuLakeError::UnknownCollection { .. }
-    ));
+    assert!(matches!(err, rulake::RuLakeError::UnknownCollection { .. }));
 }
 
 #[test]
@@ -1198,9 +1189,7 @@ fn warm_from_dir_skips_backend_and_returns_bit_exact_results() {
     let written = src.save_cache_to_dir(&key, &tmp).unwrap();
     assert_eq!(written.file_name().unwrap(), "index.rbpx");
     // Sidecar must exist alongside.
-    assert!(tmp
-        .join(rulake::RuLakeBundle::SIDECAR_FILENAME)
-        .exists());
+    assert!(tmp.join(rulake::RuLakeBundle::SIDECAR_FILENAME).exists());
 
     // Step 4: fresh RuLake, no backend. Same seed + rerank_factor so
     // the reconstructed RaBitQ codes are bit-identical to the source.

--- a/crates/gcs-backend/benches/pull_vectors.rs
+++ b/crates/gcs-backend/benches/pull_vectors.rs
@@ -40,9 +40,7 @@ fn build_parquet(n: usize, dim: usize) -> Bytes {
     let ids: Vec<i64> = (0..n as i64).collect();
     let id_arr = Arc::new(Int64Array::from(ids)) as ArrayRef;
 
-    let total: Vec<f32> = (0..(n * dim))
-        .map(|i| ((i as f32) * 0.001).sin())
-        .collect();
+    let total: Vec<f32> = (0..(n * dim)).map(|i| ((i as f32) * 0.001).sin()).collect();
     let values = Float32Array::from(total);
     let offsets: Vec<i32> = (0..=n).map(|i| (i * dim) as i32).collect();
     let offset_buffer = OffsetBuffer::new(offsets.into());

--- a/crates/gcs-backend/src/backend.rs
+++ b/crates/gcs-backend/src/backend.rs
@@ -7,13 +7,11 @@ use arrow::array::{Array, AsArray, Float32Array, Int64Array, ListArray};
 use arrow::datatypes::Float32Type;
 use futures::StreamExt;
 use object_store::path::Path as OsPath;
-use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt, gcp::GoogleCloudStorageBuilder};
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use object_store::{gcp::GoogleCloudStorageBuilder, ObjectMeta, ObjectStore, ObjectStoreExt};
 use parquet::arrow::async_reader::ParquetObjectReader;
+use parquet::arrow::ParquetRecordBatchStreamBuilder;
 
-use rulake::backend::{
-    BackendAdapter, CollectionId, PulledBatch, MAX_PULLED_DIM,
-};
+use rulake::backend::{BackendAdapter, CollectionId, PulledBatch, MAX_PULLED_DIM};
 use rulake::bundle::{Generation, RuLakeBundle};
 use rulake::error::{Result, RuLakeError};
 
@@ -167,38 +165,30 @@ impl BackendAdapter for GcsParquetBackend {
 
         let id = self.id.clone();
         let id_for_err = id.clone();
-        let (ids, vectors, dim, generation) = self
-            .inner
-            .runtime
-            .block_on(async move {
-                let head = store.head(&path).await.map_err(|e| RuLakeError::Backend {
-                    backend: id_for_err.clone(),
-                    detail: format!("HEAD {path}: {e}"),
-                })?;
-                let generation = generation_of(&head);
-                let reader = ParquetObjectReader::new(store, path.clone());
-                let builder = ParquetRecordBatchStreamBuilder::new(reader)
-                    .await
-                    .map_err(|e| RuLakeError::Backend {
-                        backend: id_for_err.clone(),
-                        detail: format!("parquet open {path}: {e}"),
-                    })?;
-                let stream = builder.build().map_err(|e| RuLakeError::Backend {
-                    backend: id_for_err.clone(),
-                    detail: format!("parquet build {path}: {e}"),
-                })?;
-                read_batches(stream, &id_for_err, &path).await
-                    .map(|(ids, vectors, dim)| (ids, vectors, dim, generation))
+        let (ids, vectors, dim, generation) = self.inner.runtime.block_on(async move {
+            let head = store.head(&path).await.map_err(|e| RuLakeError::Backend {
+                backend: id_for_err.clone(),
+                detail: format!("HEAD {path}: {e}"),
             })?;
+            let generation = generation_of(&head);
+            let reader = ParquetObjectReader::new(store, path.clone());
+            let builder = ParquetRecordBatchStreamBuilder::new(reader)
+                .await
+                .map_err(|e| RuLakeError::Backend {
+                    backend: id_for_err.clone(),
+                    detail: format!("parquet open {path}: {e}"),
+                })?;
+            let stream = builder.build().map_err(|e| RuLakeError::Backend {
+                backend: id_for_err.clone(),
+                detail: format!("parquet build {path}: {e}"),
+            })?;
+            read_batches(stream, &id_for_err, &path)
+                .await
+                .map(|(ids, vectors, dim)| (ids, vectors, dim, generation))
+        })?;
 
         // Cache the (dim, generation) for cheap current_bundle() later.
-        self.put_cached_schema(
-            collection,
-            SchemaCache {
-                dim,
-                generation,
-            },
-        );
+        self.put_cached_schema(collection, SchemaCache { dim, generation });
 
         if dim > MAX_PULLED_DIM {
             return Err(RuLakeError::InvalidParameter(format!(
@@ -251,10 +241,13 @@ impl BackendAdapter for GcsParquetBackend {
         let head_path = path.clone();
         let head_store = Arc::clone(&store);
         let generation = self.inner.runtime.block_on(async move {
-            let head = head_store.head(&head_path).await.map_err(|e| RuLakeError::Backend {
-                backend: id_head.clone(),
-                detail: format!("HEAD {head_path}: {e}"),
-            })?;
+            let head = head_store
+                .head(&head_path)
+                .await
+                .map_err(|e| RuLakeError::Backend {
+                    backend: id_head.clone(),
+                    detail: format!("HEAD {head_path}: {e}"),
+                })?;
             Ok::<u64, RuLakeError>(generation_of(&head))
         })?;
 
@@ -274,13 +267,7 @@ impl BackendAdapter for GcsParquetBackend {
         };
 
         // Update cache.
-        self.put_cached_schema(
-            collection,
-            SchemaCache {
-                dim,
-                generation,
-            },
-        );
+        self.put_cached_schema(collection, SchemaCache { dim, generation });
 
         let data_ref = format!("gs://{bucket}/{}", c.object);
         Ok(RuLakeBundle::new(
@@ -315,14 +302,13 @@ impl GcsParquetBackend {
                     backend: id.clone(),
                     detail: format!("schema: no `vector` column ({e})"),
                 })?;
-            list_element_count_estimate(field.data_type())
-                .ok_or_else(|| RuLakeError::Backend {
-                    backend: id.clone(),
-                    detail: format!(
-                        "schema: `vector` column is not a fixed-size list of floats (type: {:?})",
-                        field.data_type()
-                    ),
-                })
+            list_element_count_estimate(field.data_type()).ok_or_else(|| RuLakeError::Backend {
+                backend: id.clone(),
+                detail: format!(
+                    "schema: `vector` column is not a fixed-size list of floats (type: {:?})",
+                    field.data_type()
+                ),
+            })
         })
     }
 }

--- a/crates/gcs-backend/tests/smoke.rs
+++ b/crates/gcs-backend/tests/smoke.rs
@@ -16,7 +16,7 @@ use arrow::buffer::OffsetBuffer;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use bytes::Bytes;
-use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory, path::Path as OsPath};
+use object_store::{memory::InMemory, path::Path as OsPath, ObjectStore, ObjectStoreExt};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
@@ -29,9 +29,7 @@ fn build_parquet(n: usize, dim: usize) -> Bytes {
     let id_arr = Arc::new(Int64Array::from(ids)) as ArrayRef;
 
     // Vector column: List<Float32> with N rows of `dim` floats each.
-    let total: Vec<f32> = (0..(n * dim))
-        .map(|i| ((i as f32) * 0.001).sin())
-        .collect();
+    let total: Vec<f32> = (0..(n * dim)).map(|i| ((i as f32) * 0.001).sin()).collect();
     let values = Float32Array::from(total);
     let offsets: Vec<i32> = (0..=n).map(|i| (i * dim) as i32).collect();
     let offset_buffer = OffsetBuffer::new(offsets.into());
@@ -46,8 +44,8 @@ fn build_parquet(n: usize, dim: usize) -> Bytes {
     let batch = RecordBatch::try_new(schema.clone(), vec![id_arr, vec_arr]).unwrap();
 
     let mut buf: Vec<u8> = Vec::new();
-    let mut writer = ArrowWriter::try_new(&mut buf, schema, Some(WriterProperties::builder().build()))
-        .unwrap();
+    let mut writer =
+        ArrowWriter::try_new(&mut buf, schema, Some(WriterProperties::builder().build())).unwrap();
     writer.write(&batch).unwrap();
     writer.close().unwrap();
     buf.into()
@@ -66,10 +64,7 @@ fn pull_vectors_round_trip_offline() {
     let object = "embeddings/docs.parquet";
     let body = build_parquet(100, 16);
     rt().block_on(async {
-        store
-            .put(&OsPath::from(object), body.into())
-            .await
-            .unwrap();
+        store.put(&OsPath::from(object), body.into()).await.unwrap();
     });
 
     let backend = GcsParquetBackend::with_store("test-gcs", "fake-bucket", store).unwrap();
@@ -80,17 +75,27 @@ fn pull_vectors_round_trip_offline() {
     });
 
     assert_eq!(backend.id(), "test-gcs");
-    assert_eq!(backend.list_collections().unwrap(), vec!["docs".to_string()]);
+    assert_eq!(
+        backend.list_collections().unwrap(),
+        vec!["docs".to_string()]
+    );
 
     let PulledBatch {
-        ids, vectors, dim, generation, ..
+        ids,
+        vectors,
+        dim,
+        generation,
+        ..
     } = backend.pull_vectors("docs").unwrap();
 
     assert_eq!(ids.len(), 100, "100 rows back");
     assert_eq!(dim, 16, "schema reports dim=16");
     assert_eq!(vectors.len(), 100);
     assert_eq!(vectors[0].len(), 16);
-    assert!(generation > 0, "InMemory store reports a non-zero last_modified-derived generation");
+    assert!(
+        generation > 0,
+        "InMemory store reports a non-zero last_modified-derived generation"
+    );
     assert_eq!(ids[42], 42);
 }
 
@@ -112,10 +117,7 @@ fn current_bundle_does_not_pull_vectors_offline() {
     let object = "embeddings/witness-only.parquet";
     let body = build_parquet(10, 32);
     rt().block_on(async {
-        store
-            .put(&OsPath::from(object), body.into())
-            .await
-            .unwrap();
+        store.put(&OsPath::from(object), body.into()).await.unwrap();
     });
 
     let backend = GcsParquetBackend::with_store("test-gcs", "fake-bucket", store).unwrap();
@@ -129,7 +131,10 @@ fn current_bundle_does_not_pull_vectors_offline() {
     assert_eq!(bundle.dim, 32);
     assert_eq!(bundle.rotation_seed, 42);
     assert_eq!(bundle.rerank_factor, 20);
-    assert_eq!(bundle.data_ref, "gs://fake-bucket/embeddings/witness-only.parquet");
+    assert_eq!(
+        bundle.data_ref,
+        "gs://fake-bucket/embeddings/witness-only.parquet"
+    );
     assert_eq!(bundle.rvf_witness.len(), 64, "SHAKE-256(32) hex");
     assert!(bundle.verify_witness(), "freshly built bundle must verify");
 }
@@ -142,7 +147,8 @@ fn generation_changes_on_reupload_offline() {
     // breaks.
     let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let object = "embeddings/v.parquet";
-    let backend = GcsParquetBackend::with_store("test-gcs", "fake-bucket", Arc::clone(&store)).unwrap();
+    let backend =
+        GcsParquetBackend::with_store("test-gcs", "fake-bucket", Arc::clone(&store)).unwrap();
     backend.register(GcsParquetCollection {
         name: "v".into(),
         object: object.into(),
@@ -151,7 +157,10 @@ fn generation_changes_on_reupload_offline() {
 
     let body1 = build_parquet(5, 8);
     rt().block_on(async {
-        store.put(&OsPath::from(object), body1.into()).await.unwrap();
+        store
+            .put(&OsPath::from(object), body1.into())
+            .await
+            .unwrap();
     });
     let g1 = backend.generation("v").unwrap();
 
@@ -160,7 +169,10 @@ fn generation_changes_on_reupload_offline() {
 
     let body2 = build_parquet(5, 8);
     rt().block_on(async {
-        store.put(&OsPath::from(object), body2.into()).await.unwrap();
+        store
+            .put(&OsPath::from(object), body2.into())
+            .await
+            .unwrap();
     });
     let g2 = backend.generation("v").unwrap();
 
@@ -199,8 +211,8 @@ fn gcs_live_pull_vectors() {
         return;
     }
     let bucket = std::env::var("RULAKE_GCS_BUCKET").expect("RULAKE_GCS_BUCKET");
-    let object = std::env::var("RULAKE_GCS_OBJECT")
-        .unwrap_or_else(|_| "fixtures/docs-100k.parquet".into());
+    let object =
+        std::env::var("RULAKE_GCS_OBJECT").unwrap_or_else(|_| "fixtures/docs-100k.parquet".into());
 
     let backend = GcsParquetBackend::open_gcs("gcs-live", bucket).unwrap();
     backend.register(GcsParquetCollection {

--- a/crates/ipfs-backend/src/backend.rs
+++ b/crates/ipfs-backend/src/backend.rs
@@ -443,17 +443,15 @@ async fn kubo_add(backend: &IpfsBackend, body: Vec<u8>) -> Result<String> {
     // intermediate dir entries when the input is a directory).
     let last = text
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .next_back()
+        .rfind(|l| !l.trim().is_empty())
         .ok_or_else(|| RuLakeError::Backend {
             backend: backend.id.clone(),
             detail: "kubo add: empty response".into(),
         })?;
-    let parsed: KuboAddResponse =
-        serde_json::from_str(last).map_err(|e| RuLakeError::Backend {
-            backend: backend.id.clone(),
-            detail: format!("kubo add: parse {last:?}: {e}"),
-        })?;
+    let parsed: KuboAddResponse = serde_json::from_str(last).map_err(|e| RuLakeError::Backend {
+        backend: backend.id.clone(),
+        detail: format!("kubo add: parse {last:?}: {e}"),
+    })?;
     Ok(parsed.hash)
 }
 
@@ -546,6 +544,9 @@ mod tests {
         assert!(validate_cid_shape("Qm 123").is_err());
         assert!(validate_cid_shape("Qm\x01x").is_err());
         assert!(validate_cid_shape("QmZ4tDuvesekSs4qM5ZBKpXiZGun7S2CYtEZRB3DYXkjGx").is_ok());
-        assert!(validate_cid_shape("bafybeigdyrztktbnzdmnfvk7t6mjg6mbsj4mejxvgjlb6scxorsbcs6htu").is_ok());
+        assert!(
+            validate_cid_shape("bafybeigdyrztktbnzdmnfvk7t6mjg6mbsj4mejxvgjlb6scxorsbcs6htu")
+                .is_ok()
+        );
     }
 }

--- a/crates/ipfs-backend/tests/smoke.rs
+++ b/crates/ipfs-backend/tests/smoke.rs
@@ -40,7 +40,9 @@ async fn spawn_mock_kubo(state: MockState) -> u16 {
     let port = listener.local_addr().unwrap().port();
     tokio::spawn(async move {
         loop {
-            let Ok((stream, _)) = listener.accept().await else { break };
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
             let state = state.clone();
             tokio::spawn(async move {
                 let io = TokioIo::new(stream);
@@ -214,13 +216,7 @@ fn pull_vectors_errors_with_bundle_only_message() {
 #[test]
 fn gateway_only_mode_refuses_publish() {
     let backend = IpfsBackend::gateway_only("ipfs-gw", "https://ipfs.io").unwrap();
-    let bundle = RuLakeBundle::new(
-        "ipfs://x",
-        8,
-        42,
-        20,
-        Generation::Opaque("x".into()),
-    );
+    let bundle = RuLakeBundle::new("ipfs://x", 8, 42, 20, Generation::Opaque("x".into()));
     let err = backend.publish_bundle("c", &bundle).unwrap_err();
     let s = err.to_string();
     assert!(
@@ -260,8 +256,8 @@ fn ipfs_live_publish_and_fetch() {
         eprintln!("skip: RULAKE_IPFS_LIVE_TEST not set");
         return;
     }
-    let api = std::env::var("RULAKE_IPFS_KUBO_API")
-        .unwrap_or_else(|_| "http://127.0.0.1:5001".into());
+    let api =
+        std::env::var("RULAKE_IPFS_KUBO_API").unwrap_or_else(|_| "http://127.0.0.1:5001".into());
 
     let backend = IpfsBackend::new(
         "ipfs-live",

--- a/crates/kernel-wgpu/src/lib.rs
+++ b/crates/kernel-wgpu/src/lib.rs
@@ -263,7 +263,13 @@ impl WgpuKernel {
     /// distance buffer downloaded back to host memory.
     ///
     /// `dim` and `n` are passed as a uniform; both must fit in `u32`.
-    fn run_l2_dispatch(&self, query: &[f32], candidates_flat: &[f32], dim: u32, n: u32) -> Vec<f32> {
+    fn run_l2_dispatch(
+        &self,
+        query: &[f32],
+        candidates_flat: &[f32],
+        dim: u32,
+        n: u32,
+    ) -> Vec<f32> {
         let q_buf = self
             .device
             .create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/crates/kernel-wgpu/tests/conformance.rs
+++ b/crates/kernel-wgpu/tests/conformance.rs
@@ -32,6 +32,7 @@ fn try_kernel() -> Option<WgpuKernel> {
 /// Same LCG fixture `assert_kernel_conformant` uses, exposed here so we
 /// can drive the popcount path byte-for-byte and the L2 path
 /// set-equivalent under one helper.
+#[allow(clippy::type_complexity)]
 fn fixture(seed: u64) -> (Vec<f32>, Vec<Vec<f32>>, Vec<u64>, Vec<Vec<u64>>) {
     let dim = 16usize;
     let n = 10usize;
@@ -48,9 +49,13 @@ fn fixture(seed: u64) -> (Vec<f32>, Vec<Vec<f32>>, Vec<u64>, Vec<Vec<u64>>) {
         x * 2.0 - 1.0
     };
     let qf: Vec<f32> = (0..dim).map(|_| next_f32()).collect();
-    let cf: Vec<Vec<f32>> = (0..n).map(|_| (0..dim).map(|_| next_f32()).collect()).collect();
+    let cf: Vec<Vec<f32>> = (0..n)
+        .map(|_| (0..dim).map(|_| next_f32()).collect())
+        .collect();
     let qu: Vec<u64> = (0..dim).map(|_| next_u64()).collect();
-    let cu: Vec<Vec<u64>> = (0..n).map(|_| (0..dim).map(|_| next_u64()).collect()).collect();
+    let cu: Vec<Vec<u64>> = (0..n)
+        .map(|_| (0..dim).map(|_| next_u64()).collect())
+        .collect();
     (qf, cf, qu, cu)
 }
 

--- a/crates/mcp-ruqu/src/audit.rs
+++ b/crates/mcp-ruqu/src/audit.rs
@@ -37,7 +37,7 @@ pub struct AuditSink {
 /// Backing store for an [`AuditSink`]. v0.0.1 shipped only `Stderr`;
 /// v0.1 adds `File` so the `--audit-file` CLI flag (mcp-ruqu's `http`
 /// + `stdio` subcommands) can persist JSONL the same way mcp-rvdna and
-/// mcp-server do. Schema unchanged.
+///   mcp-server do. Schema unchanged.
 enum Inner {
     Stderr,
     File {
@@ -221,9 +221,7 @@ pub fn now_ts() -> String {
     let secs = now.as_secs();
     let millis = now.subsec_millis();
     let (year, month, day, hour, minute, second) = epoch_to_ymdhms(secs);
-    format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
-    )
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
 }
 
 fn epoch_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {

--- a/crates/mcp-ruqu/src/http.rs
+++ b/crates/mcp-ruqu/src/http.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use http::{Request, Response};
-use http_body_util::{BodyExt, combinators::BoxBody};
+use http_body_util::{combinators::BoxBody, BodyExt};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper_util::rt::{TokioExecutor, TokioIo};

--- a/crates/mcp-ruqu/src/lib.rs
+++ b/crates/mcp-ruqu/src/lib.rs
@@ -43,6 +43,6 @@ pub mod server;
 pub use audit::{AuditEntry, AuditSink, PolicyDecision};
 pub use http::{AllowBearerOnPublic, AuthMode, BearerAuth, InsecureAllowNoAuth};
 pub use server::{
-    ReplayResponse, RuquMcpServer, SimulateRequest, SimulateResponse, StubRequest,
-    StubResponse, VerifyRequest, VerifyResponse,
+    ReplayResponse, RuquMcpServer, SimulateRequest, SimulateResponse, StubRequest, StubResponse,
+    VerifyRequest, VerifyResponse,
 };

--- a/crates/mcp-ruqu/src/main.rs
+++ b/crates/mcp-ruqu/src/main.rs
@@ -176,7 +176,7 @@ fn print_help() {
 }
 
 fn init_tracing() {
-    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
     let _ = tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(fmt::layer().json().with_writer(std::io::stderr))

--- a/crates/mcp-ruqu/src/ruqu_core_engine.rs
+++ b/crates/mcp-ruqu/src/ruqu_core_engine.rs
@@ -77,7 +77,11 @@ mod tests {
     /// |0> with no gates: state vector = [1, 0]. ruqu-core matches.
     #[test]
     fn empty_one_qubit_is_ground_state() {
-        let c = Circuit { id: "test".into(), n_qubits: 1, gates: vec![] };
+        let c = Circuit {
+            id: "test".into(),
+            n_qubits: 1,
+            gates: vec![],
+        };
         let sv = simulate(&c);
         assert_eq!(sv.len(), 2);
         assert!(approx_eq(sv[0].re, 1.0) && approx_eq(sv[0].im, 0.0));
@@ -107,7 +111,10 @@ mod tests {
             n_qubits: 2,
             gates: vec![
                 WireGate::H { q: 0 },
-                WireGate::Cx { control: 0, target: 1 },
+                WireGate::Cx {
+                    control: 0,
+                    target: 1,
+                },
             ],
         };
         let sv = simulate(&c);

--- a/crates/mcp-ruqu/src/server.rs
+++ b/crates/mcp-ruqu/src/server.rs
@@ -27,14 +27,12 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError,
-    ServerHandler, ServiceExt,
     handler::server::{
         router::tool::ToolRouter,
         wrapper::{Json, Parameters},
     },
     model::{Implementation, ServerCapabilities, ServerInfo},
-    tool, tool_handler, tool_router,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
 
@@ -42,12 +40,11 @@ use rulake::{BackendAdapter, RuLake};
 use ruvector_rulake_ruqu::{
     circuit::{Circuit, Gate},
     limits::enforce_qubit_cap,
-    state_vector,
     witness::{inputs_for, ruqu_bundle},
     RuquStateVectorBackend,
 };
 
-use crate::audit::{AuditEntry, AuditSink, PolicyDecision, now_ts};
+use crate::audit::{now_ts, AuditEntry, AuditSink, PolicyDecision};
 
 // ─── Security: R-1 mitigation constants ──────────────────────────────
 
@@ -94,10 +91,7 @@ impl RuquMcpServer {
     /// `RuLake` so `ruqu_replay` can short-circuit through the
     /// cache. The brief stipulates this path "uses ruLake's cache
     /// directly via `lake.search_one`".
-    pub fn with_lake(
-        backend: Arc<RuquStateVectorBackend>,
-        lake: Arc<RuLake>,
-    ) -> Self {
+    pub fn with_lake(backend: Arc<RuquStateVectorBackend>, lake: Arc<RuLake>) -> Self {
         Self {
             backend,
             lake: Some(lake),
@@ -129,46 +123,31 @@ impl RuquMcpServer {
     /// Direct-call helper for tests: invoke `ruqu_simulate` without
     /// going through the rmcp wire. Returns the tool's response.
     #[doc(hidden)]
-    pub async fn call_simulate(
-        &self,
-        req: SimulateRequest,
-    ) -> Result<SimulateResponse, McpError> {
+    pub async fn call_simulate(&self, req: SimulateRequest) -> Result<SimulateResponse, McpError> {
         self.ruqu_simulate(Parameters(req)).await.map(|j| j.0)
     }
 
     /// Direct-call helper for tests.
     #[doc(hidden)]
-    pub async fn call_verify(
-        &self,
-        req: VerifyRequest,
-    ) -> Result<VerifyResponse, McpError> {
+    pub async fn call_verify(&self, req: VerifyRequest) -> Result<VerifyResponse, McpError> {
         self.ruqu_verify(Parameters(req)).await.map(|j| j.0)
     }
 
     /// Direct-call helper for tests.
     #[doc(hidden)]
-    pub async fn call_replay(
-        &self,
-        req: VerifyRequest,
-    ) -> Result<ReplayResponse, McpError> {
+    pub async fn call_replay(&self, req: VerifyRequest) -> Result<ReplayResponse, McpError> {
         self.ruqu_replay(Parameters(req)).await.map(|j| j.0)
     }
 
     /// Direct-call helper for tests.
     #[doc(hidden)]
-    pub async fn call_optimize(
-        &self,
-        req: StubRequest,
-    ) -> Result<StubResponse, McpError> {
+    pub async fn call_optimize(&self, req: StubRequest) -> Result<StubResponse, McpError> {
         self.ruqu_optimize(Parameters(req)).await.map(|j| j.0)
     }
 
     /// Direct-call helper for tests.
     #[doc(hidden)]
-    pub async fn call_qec_schedule(
-        &self,
-        req: StubRequest,
-    ) -> Result<StubResponse, McpError> {
+    pub async fn call_qec_schedule(&self, req: StubRequest) -> Result<StubResponse, McpError> {
         self.ruqu_qec_schedule(Parameters(req)).await.map(|j| j.0)
     }
 }
@@ -256,7 +235,9 @@ pub struct WireCircuit {
 impl From<WireCircuit> for Circuit {
     fn from(c: WireCircuit) -> Self {
         let mut out = Circuit::new(c.id, c.n_qubits);
-        for g in c.gates { out.push(g.into()); }
+        for g in c.gates {
+            out.push(g.into());
+        }
         out
     }
 }
@@ -292,7 +273,9 @@ pub struct SimulateRequest {
     pub seed: u64,
 }
 
-fn default_backend_tag() -> String { "sv".to_string() }
+fn default_backend_tag() -> String {
+    "sv".to_string()
+}
 
 /// Response shape for `ruqu_simulate`. The brief: "DON'T return the
 /// full state vector — for n=14 that's 16384 amplitudes; cap at 32
@@ -476,7 +459,8 @@ impl RuquMcpServer {
 
         // ── live path ─────────────────────────────────────────────
         let circuit: Circuit = req.circuit.into();
-        let bundle = self.backend
+        let bundle = self
+            .backend
             .execute(circuit.id.clone(), &circuit)
             .map_err(|e| {
                 self.emit_refusal(
@@ -504,11 +488,7 @@ impl RuquMcpServer {
         let sv = crate::ruqu_core_engine::simulate(&circuit);
         let dim = sv.len();
         let head_n = dim.min(32);
-        let amplitudes_head: Vec<[f64; 2]> = sv
-            .iter()
-            .take(head_n)
-            .map(|c| [c.re, c.im])
-            .collect();
+        let amplitudes_head: Vec<[f64; 2]> = sv.iter().take(head_n).map(|c| [c.re, c.im]).collect();
 
         let resp = SimulateResponse {
             witness: witness.clone(),
@@ -600,20 +580,35 @@ impl RuquMcpServer {
             request_id: None,
             tool: "ruqu_verify".into(),
             intent: Some(format!("verify:{id_for_audit}")),
-            outcome: if matches { "ok".into() } else { "refused".into() },
+            outcome: if matches {
+                "ok".into()
+            } else {
+                "refused".into()
+            },
             result_size: Some(1),
-            trust_level: Some(if matches { "verified".into() } else { "rejected".into() }),
+            trust_level: Some(if matches {
+                "verified".into()
+            } else {
+                "rejected".into()
+            }),
             duration_ms: start.elapsed().as_secs_f64() * 1000.0,
             witness_in: Some(req.witness.clone()),
             witness_out: Some(computed.clone()),
-            code: if matches { None } else { Some("RUQU_WITNESS_MISMATCH".into()) },
+            code: if matches {
+                None
+            } else {
+                Some("RUQU_WITNESS_MISMATCH".into())
+            },
             policy_decision: Some(PolicyDecision {
                 capability_required: "read".into(),
                 capability_granted: vec!["read".into()],
             }),
         });
 
-        Ok(Json(VerifyResponse { matches, computed_witness: computed }))
+        Ok(Json(VerifyResponse {
+            matches,
+            computed_witness: computed,
+        }))
     }
 
     #[tool(
@@ -696,9 +691,17 @@ impl RuquMcpServer {
             request_id: None,
             tool: "ruqu_replay".into(),
             intent: Some(format!("replay:{id_for_audit}")),
-            outcome: if matches { "ok".into() } else { "refused".into() },
+            outcome: if matches {
+                "ok".into()
+            } else {
+                "refused".into()
+            },
             result_size: Some(1),
-            trust_level: Some(if matches { "verified".into() } else { "rejected".into() }),
+            trust_level: Some(if matches {
+                "verified".into()
+            } else {
+                "rejected".into()
+            }),
             duration_ms: start.elapsed().as_secs_f64() * 1000.0,
             witness_in: Some(req.witness.clone()),
             witness_out: Some(computed.clone()),
@@ -715,7 +718,11 @@ impl RuquMcpServer {
             }),
         });
 
-        Ok(Json(ReplayResponse { matches, computed_witness: computed, cache_hit }))
+        Ok(Json(ReplayResponse {
+            matches,
+            computed_witness: computed,
+            cache_hit,
+        }))
     }
 
     #[tool(
@@ -838,17 +845,16 @@ impl RuquMcpServer {
             noise_rate: 1e-3,
             seed: Some(0xCAFEBABE),
         };
-        let result = ruqu_algorithms::surface_code::run_surface_code(&cfg)
-            .map_err(|e| {
-                self.emit_refusal(
-                    "ruqu_qec_schedule",
-                    "read",
-                    "RUQU_QEC_INTERNAL",
-                    &id_for_audit,
-                    start.elapsed().as_secs_f64() * 1000.0,
-                );
-                McpError::internal_error(format!("RUQU_QEC_INTERNAL: {e}"), None)
-            })?;
+        let result = ruqu_algorithms::surface_code::run_surface_code(&cfg).map_err(|e| {
+            self.emit_refusal(
+                "ruqu_qec_schedule",
+                "read",
+                "RUQU_QEC_INTERNAL",
+                &id_for_audit,
+                start.elapsed().as_secs_f64() * 1000.0,
+            );
+            McpError::internal_error(format!("RUQU_QEC_INTERNAL: {e}"), None)
+        })?;
 
         let resp = StubResponse {
             status: "live".into(),
@@ -981,16 +987,11 @@ fn _gate_surface_witness(_g: &Gate) {}
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for RuquMcpServer {
     fn get_info(&self) -> ServerInfo {
-        let mut info = Implementation::new(
-            "ruvector-rulake-mcp-ruqu",
-            env!("CARGO_PKG_VERSION"),
-        );
+        let mut info = Implementation::new("ruvector-rulake-mcp-ruqu", env!("CARGO_PKG_VERSION"));
         info.title = Some("ruQu MCP companion server".into());
         info.website_url = Some("https://github.com/ruvnet/RuLake".into());
 
-        let mut init = ServerInfo::new(
-            ServerCapabilities::builder().enable_tools().build(),
-        );
+        let mut init = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
         init.server_info = info;
         init.instructions = Some(
             "ruQu MCP companion server (ADR-008 §6 v0.0.1). Five tools: \
@@ -1014,7 +1015,10 @@ mod tests {
             n_qubits: 2,
             gates: vec![
                 WireGate::H { q: 0 },
-                WireGate::Cx { control: 0, target: 1 },
+                WireGate::Cx {
+                    control: 0,
+                    target: 1,
+                },
             ],
             id: "bell-pair-v0".to_string(),
         }
@@ -1148,7 +1152,9 @@ mod tests {
         assert_eq!(resp.status, "live");
         assert!(!resp.v01_planned);
         assert!(!resp.v02_planned);
-        assert!(resp.note.contains("ruqu-algorithms::surface_code::run_surface_code"));
+        assert!(resp
+            .note
+            .contains("ruqu-algorithms::surface_code::run_surface_code"));
         assert_eq!(resp.code_distance, Some(3));
         assert_eq!(resp.total_cycles, Some(100));
         // logical_error_rate is empirical — bounded by [0, 1] but content varies.

--- a/crates/mcp-ruqu/tests/integration.rs
+++ b/crates/mcp-ruqu/tests/integration.rs
@@ -6,10 +6,8 @@
 //!   2. R-2 cap enforcement: simulate with `n_qubits = 20` → assert
 //!      response (here: McpError) carries `RUQU_QUBIT_CAP_EXCEEDED`.
 
-use ruvector_rulake_mcp_ruqu::{
-    RuquMcpServer, SimulateRequest, VerifyRequest,
-};
 use ruvector_rulake_mcp_ruqu::server::{WireCircuit, WireGate};
+use ruvector_rulake_mcp_ruqu::{RuquMcpServer, SimulateRequest, VerifyRequest};
 
 /// 1. Bell-pair simulate → verify round-trip.
 #[tokio::test]
@@ -20,7 +18,10 @@ async fn bell_pair_simulate_then_verify_matches() {
         n_qubits: 2,
         gates: vec![
             WireGate::H { q: 0 },
-            WireGate::Cx { control: 0, target: 1 },
+            WireGate::Cx {
+                control: 0,
+                target: 1,
+            },
         ],
         id: "bell-pair-integration".to_string(),
     };

--- a/crates/mcp-rvdna/src/http.rs
+++ b/crates/mcp-rvdna/src/http.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use http::{Request, Response};
-use http_body_util::{BodyExt, combinators::BoxBody};
+use http_body_util::{combinators::BoxBody, BodyExt};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper_util::rt::{TokioExecutor, TokioIo};

--- a/crates/mcp-rvdna/src/main.rs
+++ b/crates/mcp-rvdna/src/main.rs
@@ -15,8 +15,7 @@ use std::sync::Arc;
 use anyhow::Context;
 
 use ruvector_rulake_mcp_rvdna::{
-    AllowBearerOnPublic, AuditSink, AuthMode, CapabilitySet, InsecureAllowNoAuth,
-    RvdnaMcpServer,
+    AllowBearerOnPublic, AuditSink, AuthMode, CapabilitySet, InsecureAllowNoAuth, RvdnaMcpServer,
 };
 use ruvector_rulake_rvdna::{RvdnaCollection, RvdnaT0Backend};
 
@@ -68,7 +67,9 @@ async fn main() -> anyhow::Result<()> {
         };
         let coll = RvdnaCollection {
             ids: (0..64u64).collect(),
-            vectors: (0..64).map(|_| (0..8).map(|_| next_f32()).collect()).collect(),
+            vectors: (0..64)
+                .map(|_| (0..8).map(|_| next_f32()).collect())
+                .collect(),
             dim: 8,
             generation: 1,
         };
@@ -200,7 +201,7 @@ fn print_help() {
 }
 
 fn init_tracing() {
-    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
     let _ = tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(fmt::layer().json().with_writer(std::io::stderr))

--- a/crates/mcp-rvdna/src/policy.rs
+++ b/crates/mcp-rvdna/src/policy.rs
@@ -2,7 +2,7 @@
 //!
 //! Mirrors `mcp-server::policy` but with rvdna scope vocabulary:
 //! - `read`     — exposes `rvdna_find`, `rvdna_call_variants`,
-//!                `rvdna_translate`, `rvdna_score`
+//!   `rvdna_translate`, `rvdna_score`
 //! - `internal` — adds `rvdna_lineage` (operator/SRE/Console-trust)
 //! - `clinical` — reserved for `rvdna_call_variants` PHI flow (v0.1)
 //! - `admin`    — reserved (v0.1+); no admin tools in v0.0.1

--- a/crates/mcp-rvdna/src/real_compute.rs
+++ b/crates/mcp-rvdna/src/real_compute.rs
@@ -48,7 +48,11 @@ pub fn knn_l2(
             (id, acc)
         })
         .collect();
-    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal).then(a.0.cmp(&b.0)));
+    scored.sort_by(|a, b| {
+        a.1.partial_cmp(&b.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.0.cmp(&b.0))
+    });
     scored.truncate(k);
     Ok(scored)
 }
@@ -109,18 +113,23 @@ pub fn translate_dna(dna: &str) -> String {
         }
     };
 
-    let bytes: Vec<u8> = dna.bytes().filter_map(|b| {
-        match b.to_ascii_uppercase() {
-            b'A' | b'C' | b'G' | b'T' => Some(b.to_ascii_uppercase()),
-            _ => None,  // skip whitespace, Ns, anything non-canonical
-        }
-    }).collect();
+    let bytes: Vec<u8> = dna
+        .bytes()
+        .filter_map(|b| {
+            match b.to_ascii_uppercase() {
+                b'A' | b'C' | b'G' | b'T' => Some(b.to_ascii_uppercase()),
+                _ => None, // skip whitespace, Ns, anything non-canonical
+            }
+        })
+        .collect();
 
     let mut protein = String::with_capacity(bytes.len() / 3);
     let mut i = 0;
     while i + 3 <= bytes.len() {
         let aa = codon_table(bytes[i], bytes[i + 1], bytes[i + 2]);
-        if aa == '*' { break; }
+        if aa == '*' {
+            break;
+        }
         protein.push(aa);
         i += 3;
     }

--- a/crates/mcp-rvdna/src/registry.rs
+++ b/crates/mcp-rvdna/src/registry.rs
@@ -150,9 +150,7 @@ pub enum WitnessCheckError {
     },
     #[error("RVDNA_BACKEND_ERROR: {0}")]
     Backend(String),
-    #[error(
-        "RVDNA_WITNESS_DRIFT: pinned={pinned} live={live} — backend mutated since register"
-    )]
+    #[error("RVDNA_WITNESS_DRIFT: pinned={pinned} live={live} — backend mutated since register")]
     Drift { pinned: String, live: String },
 }
 

--- a/crates/mcp-rvdna/src/server.rs
+++ b/crates/mcp-rvdna/src/server.rs
@@ -20,8 +20,6 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError,
-    ServerHandler, ServiceExt,
     handler::server::{
         router::tool::ToolRouter,
         wrapper::{Json, Parameters},
@@ -32,13 +30,13 @@ use rmcp::{
         ServerInfo,
     },
     service::RequestContext,
-    tool, tool_handler, tool_router,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
 
 use rulake::backend::BackendAdapter;
 
-use crate::audit::{AuditEntry, AuditSink, PolicyDecision, now_ts};
+use crate::audit::{now_ts, AuditEntry, AuditSink, PolicyDecision};
 use crate::policy::{Capability, CapabilitySet};
 use crate::registry::{RvdnaRegistry, WitnessCheckError};
 
@@ -248,7 +246,8 @@ impl RvdnaMcpServer {
                 &args.collection,
                 &args.query,
                 args.k as usize,
-            ).map_err(|e| McpError::internal_error(format!("RVDNA_FIND_INTERNAL: {e}"), None))?;
+            )
+            .map_err(|e| McpError::internal_error(format!("RVDNA_FIND_INTERNAL: {e}"), None))?;
             let hits: Vec<FindHit> = hits_raw
                 .into_iter()
                 .map(|(id, score)| FindHit { id, score })
@@ -458,6 +457,7 @@ impl RvdnaMcpServer {
     /// Outcome/code derived from the `Result` so the call site doesn't
     /// have to reshape state — mirrors `mcp-server::server::audit_mutation`
     /// (commit 56b497b).
+    #[allow(clippy::too_many_arguments)]
     fn audit_tool<T>(
         &self,
         tool: &str,
@@ -478,8 +478,6 @@ impl RvdnaMcpServer {
                     ("refused", Some("RVDNA_UNKNOWN_COLLECTION".to_string()))
                 } else if msg.contains("RVDNA_CAPABILITY_REFUSED") {
                     ("refused", Some("RVDNA_CAPABILITY_REFUSED".to_string()))
-                } else if msg.starts_with("RVDNA_INTERNAL") {
-                    ("error", Some("RVDNA_INTERNAL".to_string()))
                 } else {
                     ("error", Some("RVDNA_INTERNAL".to_string()))
                 }
@@ -588,8 +586,10 @@ impl ServerHandler for RvdnaMcpServer {
             .into_iter()
             .filter(|t| self.capabilities.has(required_cap_for_tool(&t.name)))
             .collect();
-        let mut result = ListToolsResult::default();
-        result.tools = tools;
+        let result = ListToolsResult {
+            tools,
+            ..ListToolsResult::default()
+        };
         Ok(result)
     }
 
@@ -721,7 +721,11 @@ mod tests {
         // is id 0 with score 0.
         assert!(!resp.0.stub, "Phase B: rvdna_find runs real kNN");
         assert!(!resp.0.witness.is_empty(), "live witness present");
-        assert_eq!(resp.0.hits.len(), 4, "all 4 registered vectors returned (k=5 > n=4)");
+        assert_eq!(
+            resp.0.hits.len(),
+            4,
+            "all 4 registered vectors returned (k=5 > n=4)"
+        );
         assert_eq!(resp.0.hits[0].id, 0, "closest = id 0 ([0;8] vs [0;8])");
         assert_eq!(resp.0.hits[0].score, 0.0, "exact match → distance 0");
     }

--- a/crates/mcp-rvdna/tests/http_e2e.rs
+++ b/crates/mcp-rvdna/tests/http_e2e.rs
@@ -23,8 +23,8 @@ use ruvector_rulake_mcp_rvdna::{
 use ruvector_rulake_rvdna::{RvdnaCollection, RvdnaT0Backend};
 
 fn make_server() -> (RvdnaMcpServer, String) {
-    let server = RvdnaMcpServer::new()
-        .with_capabilities(CapabilitySet::from_csv("read,internal").unwrap());
+    let server =
+        RvdnaMcpServer::new().with_capabilities(CapabilitySet::from_csv("read,internal").unwrap());
     let be = Arc::new(RvdnaT0Backend::new("rvdna-e2e"));
     be.put_collection(
         "chr1",
@@ -198,12 +198,11 @@ async fn rvdna_lineage_round_trips_pinned_witness_over_http() {
         live, expected_witness,
         "live re-derived witness must equal pinned (no drift)"
     );
-    assert_eq!(
+    assert!(
         payload
             .get("witness_verified")
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
-        true,
         "witness_verified must be true on a successful lineage call"
     );
 }

--- a/crates/mcp-server/benches/audit_sink.rs
+++ b/crates/mcp-server/benches/audit_sink.rs
@@ -50,16 +50,13 @@ fn bench_emit_below_capacity(c: &mut Criterion) {
     // alloc dominates an otherwise trivial body.
     let mut group = c.benchmark_group("mcp_audit_emit_below_cap");
     group.bench_function("push_only", |b| {
-        b.iter_with_setup(
-            AuditSink::stderr,
-            |sink| {
-                // 100 emits — well under the 256 cap.
-                for i in 0..100u64 {
-                    sink.emit(entry(i));
-                }
-                black_box(sink);
-            },
-        );
+        b.iter_with_setup(AuditSink::stderr, |sink| {
+            // 100 emits — well under the 256 cap.
+            for i in 0..100u64 {
+                sink.emit(entry(i));
+            }
+            black_box(sink);
+        });
     });
     group.finish();
 }

--- a/crates/mcp-server/benches/tools_list_filter.rs
+++ b/crates/mcp-server/benches/tools_list_filter.rs
@@ -85,12 +85,18 @@ fn bench_capabilityset_from_csv(c: &mut Criterion) {
             "8",
             "read,publish,admin,internal,read,publish,admin,internal".into(),
         ),
-        ("64", (0..64).map(|i| {
-            // Mix in the four real labels at fixed slots, garbage
-            // labels would error out — instead repeat the four real
-            // ones to get a 64-token CSV that still parses.
-            ["read", "publish", "admin", "internal"][i % 4]
-        }).collect::<Vec<_>>().join(",")),
+        (
+            "64",
+            (0..64)
+                .map(|i| {
+                    // Mix in the four real labels at fixed slots, garbage
+                    // labels would error out — instead repeat the four real
+                    // ones to get a 64-token CSV that still parses.
+                    ["read", "publish", "admin", "internal"][i % 4]
+                })
+                .collect::<Vec<_>>()
+                .join(","),
+        ),
     ];
     for (label, csv) in &csvs {
         group.bench_with_input(BenchmarkId::from_parameter(label), csv, |b, csv| {
@@ -103,5 +109,9 @@ fn bench_capabilityset_from_csv(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_tools_list_filter, bench_capabilityset_from_csv);
+criterion_group!(
+    benches,
+    bench_tools_list_filter,
+    bench_capabilityset_from_csv
+);
 criterion_main!(benches);

--- a/crates/mcp-server/src/allow.rs
+++ b/crates/mcp-server/src/allow.rs
@@ -43,7 +43,9 @@ impl AllowList {
             let re = Regex::new(&anchored).map_err(|e| {
                 anyhow::anyhow!(
                     "[[allow]] block backend={:?} collection={:?}: bad regex: {}",
-                    b.backend, b.collection, e
+                    b.backend,
+                    b.collection,
+                    e
                 )
             })?;
             let caps: Result<Vec<Capability>, _> =
@@ -140,7 +142,9 @@ impl std::fmt::Display for AllowDenied {
             AllowDeniedReason::CollectionAllowedButCapNotGranted => write!(
                 f,
                 "RULAKE_ALLOWLIST_DENIED: {}/{} matched but cap `{}` not granted",
-                self.backend, self.collection, self.cap.label()
+                self.backend,
+                self.collection,
+                self.cap.label()
             ),
         }
     }

--- a/crates/mcp-server/src/audit.rs
+++ b/crates/mcp-server/src/audit.rs
@@ -206,9 +206,7 @@ pub fn now_ts() -> String {
     // Hand-roll an ISO-8601 string to avoid pulling chrono into the
     // dep tree just for a timestamp. Year 9999 is fine.
     let (year, month, day, hour, minute, second) = epoch_to_ymdhms(secs);
-    format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
-    )
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
 }
 
 fn epoch_to_ymdhms(secs: u64) -> (u32, u32, u32, u32, u32, u32) {

--- a/crates/mcp-server/src/auth.rs
+++ b/crates/mcp-server/src/auth.rs
@@ -13,14 +13,14 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use http::{HeaderMap, StatusCode};
-use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 
 use crate::jwks::JwksKeys;
-use crate::policy::CapabilitySet;
 #[cfg(test)]
 use crate::policy::Capability;
+use crate::policy::CapabilitySet;
 
 /// Bearer-token verifier. Cheap to clone (Arc-wrapped state).
 #[derive(Clone)]
@@ -202,16 +202,15 @@ impl JwtAuth {
                     .unwrap_or_else(|e| panic!("invalid RSA PEM: {e}")),
             ),
             JwtKey::EcPem(bytes) => KeyMode::Static(
-                DecodingKey::from_ec_pem(&bytes)
-                    .unwrap_or_else(|e| panic!("invalid EC PEM: {e}")),
+                DecodingKey::from_ec_pem(&bytes).unwrap_or_else(|e| panic!("invalid EC PEM: {e}")),
             ),
             JwtKey::Jwks(keys) => KeyMode::Jwks(keys),
         };
         let mut validation =
             Validation::new(*config.algorithms.first().unwrap_or(&Algorithm::HS256));
         validation.algorithms = config.algorithms;
-        validation.set_issuer(&[config.issuer.clone()]);
-        validation.set_audience(&[config.audience.clone()]);
+        validation.set_issuer(std::slice::from_ref(&config.issuer));
+        validation.set_audience(std::slice::from_ref(&config.audience));
         Self {
             inner: Arc::new(JwtInner {
                 key_mode: mode,
@@ -320,11 +319,14 @@ pub fn scopes_to_caps(scopes: &HashSet<String>) -> CapabilitySet {
 #[cfg(test)]
 mod jwt_tests {
     use super::*;
-    use jsonwebtoken::{EncodingKey, Header, encode};
+    use jsonwebtoken::{encode, EncodingKey, Header};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn now_secs() -> u64 {
-        SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
     }
 
     fn sign(claims: &serde_json::Value, secret: &[u8]) -> String {
@@ -351,7 +353,10 @@ mod jwt_tests {
         });
         let token = sign(&claims, &secret);
         let mut h = HeaderMap::new();
-        h.insert(http::header::AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+        h.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
 
         let p = auth.verify(&h).expect("token must validate");
         assert_eq!(p.principal, "oauth:alice");
@@ -379,7 +384,10 @@ mod jwt_tests {
         });
         let token = sign(&claims, &secret);
         let mut h = HeaderMap::new();
-        h.insert(http::header::AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+        h.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
         assert_eq!(auth.verify(&h).unwrap_err(), StatusCode::UNAUTHORIZED);
     }
 
@@ -402,14 +410,17 @@ mod jwt_tests {
         });
         let token = sign(&claims, &secret);
         let mut h = HeaderMap::new();
-        h.insert(http::header::AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+        h.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
         assert_eq!(auth.verify(&h).unwrap_err(), StatusCode::UNAUTHORIZED);
     }
 
     #[test]
     fn jwt_rejects_wrong_signature() {
         let secret = b"test-secret-32-bytes-long-okay-pls!".to_vec();
-        let other  = b"WRONG-secret-32-bytes-long-okay-OK?".to_vec();
+        let other = b"WRONG-secret-32-bytes-long-okay-OK?".to_vec();
         let auth = JwtAuth::new(JwtConfig {
             key: JwtKey::Hmac(secret.clone()),
             issuer: "https://idp.example".into(),
@@ -423,9 +434,12 @@ mod jwt_tests {
             "exp": now_secs() + 60,
             "scope": "mcp:rulake:read",
         });
-        let token = sign(&claims, &other);   // signed with the wrong key
+        let token = sign(&claims, &other); // signed with the wrong key
         let mut h = HeaderMap::new();
-        h.insert(http::header::AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+        h.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
         assert_eq!(auth.verify(&h).unwrap_err(), StatusCode::UNAUTHORIZED);
     }
 
@@ -447,7 +461,10 @@ mod jwt_tests {
         });
         let token = sign(&claims, &secret);
         let mut h = HeaderMap::new();
-        h.insert(http::header::AUTHORIZATION, format!("Bearer {token}").parse().unwrap());
+        h.insert(
+            http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
         let p = auth.verify(&h).unwrap();
         assert!(p.capabilities.has(Capability::Admin));
     }

--- a/crates/mcp-server/src/config.rs
+++ b/crates/mcp-server/src/config.rs
@@ -110,18 +110,15 @@ pub struct AllowBlock {
     pub caps: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
 #[serde(tag = "mode", rename_all = "PascalCase")]
 pub enum ConsistencyConfig {
+    #[default]
     Fresh,
-    Eventual { ttl_ms: u64 },
+    Eventual {
+        ttl_ms: u64,
+    },
     Frozen,
-}
-
-impl Default for ConsistencyConfig {
-    fn default() -> Self {
-        Self::Fresh
-    }
 }
 
 impl ConsistencyConfig {

--- a/crates/mcp-server/src/http.rs
+++ b/crates/mcp-server/src/http.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use http::{Request, Response, StatusCode};
-use http_body_util::{BodyExt, Full, combinators::BoxBody};
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -27,7 +27,7 @@ use rmcp::transport::streamable_http_server::tower::{
 };
 
 use crate::auth::{BearerAuth, JwtAuth};
-use crate::mtls::{MtlsConfig, build_acceptor as build_mtls_acceptor};
+use crate::mtls::{build_acceptor as build_mtls_acceptor, MtlsConfig};
 use crate::policy::{CapabilitySet, REQUEST_CAPS};
 use crate::ratelimit::{LayeredRateLimiter, RateLimitDecision};
 use crate::replay::ReplayGuard;
@@ -89,6 +89,7 @@ pub async fn serve(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn serve_with_guards(
     server: RuLakeMcpServer,
     bind: SocketAddr,
@@ -120,7 +121,10 @@ pub async fn serve_with_guards(
         _ => {}
     }
     tracing::info!(rate_limit = %rate_limit.config_summary(), "rate-limit policy");
-    tracing::info!(replay_window_used = replay.window_used(), "replay-guard initialized");
+    tracing::info!(
+        replay_window_used = replay.window_used(),
+        "replay-guard initialized"
+    );
 
     // Build the rmcp Streamable HTTP service. We hand it a service
     // factory so each session gets its own RuLakeMcpServer clone (the
@@ -230,8 +234,14 @@ pub async fn serve_with_guards(
                                 let mtls_fp = mtls_fp.clone();
                                 async move {
                                     handle(
-                                        req, mcp_service, auth, peer, replay, rate_limit,
-                                        sessions, mtls_fp,
+                                        req,
+                                        mcp_service,
+                                        auth,
+                                        peer,
+                                        replay,
+                                        rate_limit,
+                                        sessions,
+                                        mtls_fp,
                                     )
                                     .await
                                 }
@@ -264,7 +274,14 @@ pub async fn serve_with_guards(
                 let mtls_fp = mtls_fingerprint.clone();
                 async move {
                     handle(
-                        req, mcp_service, auth, peer, replay, rate_limit, sessions, mtls_fp,
+                        req,
+                        mcp_service,
+                        auth,
+                        peer,
+                        replay,
+                        rate_limit,
+                        sessions,
+                        mtls_fp,
                     )
                     .await
                 }
@@ -288,6 +305,7 @@ fn auth_label(a: &AuthMode) -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle(
     req: Request<Incoming>,
     mcp_service: StreamableHttpService<RuLakeMcpServer, LocalSessionManager>,
@@ -345,7 +363,10 @@ async fn handle(
             // (the same env var that loosens the DNS-rebinding guard
             // for proxied deployments) and fall back to a stable
             // pseudo-principal so sessions are usable.
-            principal = if std::env::var("RULAKE_ALLOWED_HOSTS").map(|v| !v.trim().is_empty()).unwrap_or(false) {
+            principal = if std::env::var("RULAKE_ALLOWED_HOSTS")
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false)
+            {
                 "anon:proxied".to_string()
             } else {
                 format!("anon:{peer}")
@@ -419,7 +440,10 @@ async fn handle(
                 );
             }
         }
-        SessionDecision::Mismatch { expected_principal, presented_principal } => {
+        SessionDecision::Mismatch {
+            expected_principal,
+            presented_principal,
+        } => {
             tracing::warn!(
                 ?peer,
                 session = %session_id,
@@ -443,10 +467,7 @@ async fn handle(
         .to_string();
     if let Err(replay_err) = replay.check(&request_id) {
         tracing::warn!(?peer, principal = %principal, %replay_err, "replay rejected");
-        return Ok(error_response(
-            StatusCode::CONFLICT,
-            "replay",
-        ));
+        return Ok(error_response(StatusCode::CONFLICT, "replay"));
     }
 
     // 3. Per-process rate-limit gate. Per-(principal,backend,collection)
@@ -511,7 +532,9 @@ async fn handle(
 }
 
 fn error_response(status: StatusCode, msg: &str) -> Response<BoxBody<Bytes, Infallible>> {
-    let body = Full::new(Bytes::from(msg.to_string())).map_err(|e| match e {}).boxed();
+    let body = Full::new(Bytes::from(msg.to_string()))
+        .map_err(|e| match e {})
+        .boxed();
     Response::builder()
         .status(status)
         .header(http::header::CONTENT_TYPE, "text/plain")
@@ -527,7 +550,9 @@ fn degraded_response(
     retry_after_ms: u32,
     json_body: String,
 ) -> Response<BoxBody<Bytes, Infallible>> {
-    let body = Full::new(Bytes::from(json_body)).map_err(|e| match e {}).boxed();
+    let body = Full::new(Bytes::from(json_body))
+        .map_err(|e| match e {})
+        .boxed();
     let retry_after_secs = (retry_after_ms.div_ceil(1000)).max(1);
     Response::builder()
         .status(StatusCode::TOO_MANY_REQUESTS)

--- a/crates/mcp-server/src/jwks.rs
+++ b/crates/mcp-server/src/jwks.rs
@@ -250,7 +250,6 @@ mod tests {
                 "qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q".into()
             ),
             e: Some("AQAB".into()),
-            ..Jwk { kid: None, kty: String::new(), alg: None, n: None, e: None }
         };
         let (kid, _key) = parse_jwk(&j).expect("RSA parse");
         assert_eq!(kid, "kid-1");

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -36,9 +36,10 @@ pub use audit::{AuditEntry, AuditSink};
 pub use auth::{BearerAuth, JwtAuth, JwtConfig};
 pub use config::McpConfig;
 pub use http::{AllowBearerOnPublic, AuthMode, InsecureAllowNoAuth};
-pub use jwks::{JwksKeys, spawn_refresh_task as spawn_jwks_refresh};
-pub use mtls::{MtlsConfig, build_acceptor as build_mtls_acceptor, cert_sha256_hex,
-                principal_for_client_cert};
+pub use jwks::{spawn_refresh_task as spawn_jwks_refresh, JwksKeys};
+pub use mtls::{
+    build_acceptor as build_mtls_acceptor, cert_sha256_hex, principal_for_client_cert, MtlsConfig,
+};
 pub use policy::{Capability, CapabilitySet};
 pub use ratelimit::{LayeredRateLimiter, RateLimitDecision};
 pub use replay::ReplayGuard;

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -8,11 +8,11 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use jsonwebtoken::Algorithm;
+use ruvector_rulake_mcp::auth::JwtKey;
 use ruvector_rulake_mcp::{
     AllowBearerOnPublic, AuditSink, AuthMode, BearerAuth, CapabilitySet, InsecureAllowNoAuth,
     JwksKeys, JwtAuth, JwtConfig, McpConfig, MtlsConfig, RuLakeMcpServer,
 };
-use ruvector_rulake_mcp::auth::JwtKey;
 use std::sync::Arc;
 
 #[tokio::main(flavor = "multi_thread")]
@@ -105,7 +105,8 @@ async fn build_auth(http: &HttpArgs) -> anyhow::Result<AuthMode> {
             // (rotation set fetched in the background).
             let key = if let Some(p) = &http.jwt_secret_file {
                 JwtKey::Hmac(
-                    std::fs::read(p).with_context(|| format!("loading jwt secret: {}", p.display()))?,
+                    std::fs::read(p)
+                        .with_context(|| format!("loading jwt secret: {}", p.display()))?,
                 )
             } else if let Some(p) = &http.jwt_rsa_pem_file {
                 JwtKey::RsaPem(
@@ -184,7 +185,7 @@ struct Args {
 #[derive(Debug)]
 enum Transport {
     Stdio,
-    Http(HttpArgs),
+    Http(Box<HttpArgs>),
 }
 
 #[derive(Debug)]
@@ -208,10 +209,6 @@ struct HttpArgs {
 }
 
 fn parse_args() -> anyhow::Result<Args> {
-    // `transport` is assigned exactly once below from `transport_kind`
-    // after CLI parsing completes; declared without an initial value
-    // so the compiler doesn't warn about the dead `None`.
-    let transport: Option<Transport>;
     let mut config = None;
     let mut capabilities: Option<String> = None;
     let mut audit_file: Option<PathBuf> = None;
@@ -242,9 +239,7 @@ fn parse_args() -> anyhow::Result<Args> {
             "stdio" => transport_kind = Some("stdio"),
             "http" => transport_kind = Some("http"),
             "--config" => {
-                config = Some(PathBuf::from(
-                    it.next().context("--config expects a path")?,
-                ));
+                config = Some(PathBuf::from(it.next().context("--config expects a path")?));
             }
             "--capabilities" => {
                 capabilities = Some(it.next().context("--capabilities expects CSV")?);
@@ -281,10 +276,9 @@ fn parse_args() -> anyhow::Result<Args> {
                 http_jwt_audience = Some(it.next().context("--jwt-audience expects URL")?);
             }
             "--jwt-alg" => {
-                http_jwt_alg = Some(
-                    it.next()
-                        .context("--jwt-alg expects HS256|HS384|HS512|RS256|RS384|RS512|ES256|ES384")?,
-                );
+                http_jwt_alg = Some(it.next().context(
+                    "--jwt-alg expects HS256|HS384|HS512|RS256|RS384|RS512|ES256|ES384",
+                )?);
             }
             "--jwt-rsa-pem-file" => {
                 http_jwt_rsa_pem_file = Some(PathBuf::from(
@@ -301,8 +295,10 @@ fn parse_args() -> anyhow::Result<Args> {
             }
             "--jwt-jwks-refresh-secs" => {
                 let s = it.next().context("--jwt-jwks-refresh-secs expects N")?;
-                http_jwt_jwks_refresh_secs =
-                    Some(s.parse().with_context(|| format!("--jwt-jwks-refresh-secs {s:?}"))?);
+                http_jwt_jwks_refresh_secs = Some(
+                    s.parse()
+                        .with_context(|| format!("--jwt-jwks-refresh-secs {s:?}"))?,
+                );
             }
             "--tls-cert-file" => {
                 http_tls_cert_file = Some(PathBuf::from(
@@ -327,11 +323,11 @@ fn parse_args() -> anyhow::Result<Args> {
         }
     }
 
-    transport = match transport_kind.unwrap_or("stdio") {
+    let transport = match transport_kind.unwrap_or("stdio") {
         "stdio" => Some(Transport::Stdio),
         "http" => {
             let bind = http_bind.unwrap_or_else(|| "127.0.0.1:7440".parse().unwrap());
-            Some(Transport::Http(HttpArgs {
+            Some(Transport::Http(Box::new(HttpArgs {
                 bind,
                 auth: http_auth,
                 bearer_token_file: http_token_file,
@@ -348,7 +344,7 @@ fn parse_args() -> anyhow::Result<Args> {
                 tls_cert_file: http_tls_cert_file,
                 tls_key_file: http_tls_key_file,
                 client_ca_file: http_client_ca_file,
-            }))
+            })))
         }
         _ => unreachable!(),
     };
@@ -407,7 +403,7 @@ fn print_help() {
 }
 
 fn init_tracing() {
-    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
     let _ = tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .with(fmt::layer().json().with_writer(std::io::stderr))

--- a/crates/mcp-server/src/mtls.rs
+++ b/crates/mcp-server/src/mtls.rs
@@ -51,7 +51,9 @@ pub fn build_acceptor(config: &MtlsConfig) -> anyhow::Result<TlsAcceptor> {
     let mut key_reader = std::io::BufReader::new(&config.server_key_pem[..]);
     let server_key: PrivateKeyDer<'static> = private_key(&mut key_reader)
         .map_err(|e| anyhow::anyhow!("server key PEM: {e}"))?
-        .ok_or_else(|| anyhow::anyhow!("server key PEM contained no recognized PRIVATE KEY block"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("server key PEM contained no recognized PRIVATE KEY block")
+        })?;
 
     // Client CA(s) we'll trust.
     let mut ca_reader = std::io::BufReader::new(&config.client_ca_pem[..]);
@@ -59,7 +61,9 @@ pub fn build_acceptor(config: &MtlsConfig) -> anyhow::Result<TlsAcceptor> {
     let mut added = 0usize;
     for cert in certs(&mut ca_reader) {
         let cert = cert.map_err(|e| anyhow::anyhow!("client CA PEM: {e}"))?;
-        client_root.add(cert).map_err(|e| anyhow::anyhow!("client CA add: {e}"))?;
+        client_root
+            .add(cert)
+            .map_err(|e| anyhow::anyhow!("client CA add: {e}"))?;
         added += 1;
     }
     if added == 0 {

--- a/crates/mcp-server/src/planner.rs
+++ b/crates/mcp-server/src/planner.rs
@@ -189,11 +189,21 @@ impl Default for Budget {
     }
 }
 
-fn default_max_latency_ms() -> u64 { 100 }
-fn default_max_backends() -> u32 { 3 }
-fn default_max_results() -> u32 { 20 }
-fn default_max_rerank() -> u32 { 20 }
-fn default_risk() -> Risk { Risk::Medium }
+fn default_max_latency_ms() -> u64 {
+    100
+}
+fn default_max_backends() -> u32 {
+    3
+}
+fn default_max_results() -> u32 {
+    20
+}
+fn default_max_rerank() -> u32 {
+    20
+}
+fn default_risk() -> Risk {
+    Risk::Medium
+}
 
 #[derive(Debug, Deserialize, JsonSchema, Default)]
 pub struct Policy {
@@ -205,7 +215,9 @@ pub struct Policy {
     pub min_collections_hit: u32,
 }
 
-fn default_min_collections_hit() -> u32 { 1 }
+fn default_min_collections_hit() -> u32 {
+    1
+}
 
 // ─── Response (mirror ADR-004 §4a) ────────────────────────────────────
 
@@ -469,10 +481,13 @@ pub struct TracedQueryResponse {
 
 #[derive(Debug)]
 pub enum PlanError {
-    Refused(QueryResponse),
+    Refused(Box<QueryResponse>),
     /// Backpressure — the response shape is wrapped at the call site
     /// into the `_meta.rulake.degraded` block per ADR-004 §6.
-    Degraded { inflight: usize, cap: usize },
+    Degraded {
+        inflight: usize,
+        cap: usize,
+    },
     /// Internal — bubble up as a tool-level isError.
     Internal(String),
 }
@@ -531,7 +546,7 @@ impl Planner {
             Capability::Publish,
         ) {
             Ok(rs) => rs,
-            Err(PlanError::Refused(resp)) => return Ok(resp),
+            Err(PlanError::Refused(resp)) => return Ok(*resp),
             Err(e) => return Err(e),
         };
         if routes.is_empty() {
@@ -539,7 +554,10 @@ impl Planner {
                 "refresh",
                 "no allowed routes",
                 ReasonCode::PolicyRefusedAllowlist,
-                vec![], vec![], start, req.budget.max_latency_ms,
+                vec![],
+                vec![],
+                start,
+                req.budget.max_latency_ms,
             ));
         }
 
@@ -548,15 +566,17 @@ impl Planner {
         let dir = std::path::PathBuf::from(&r.bundle_dir);
         let submit = self
             .workers
-            .submit(move || -> Result<Vec<(String, rulake::RefreshResult)>, rulake::RuLakeError> {
-                let mut out = Vec::with_capacity(routes_for_run.len());
-                for (b, c) in &routes_for_run {
-                    let key = (b.clone(), c.clone());
-                    let res = lake.refresh_from_bundle_dir(&key, &dir)?;
-                    out.push((b.clone(), res));
-                }
-                Ok(out)
-            })
+            .submit(
+                move || -> Result<Vec<(String, rulake::RefreshResult)>, rulake::RuLakeError> {
+                    let mut out = Vec::with_capacity(routes_for_run.len());
+                    for (b, c) in &routes_for_run {
+                        let key = (b.clone(), c.clone());
+                        let res = lake.refresh_from_bundle_dir(&key, &dir)?;
+                        out.push((b.clone(), res));
+                    }
+                    Ok(out)
+                },
+            )
             .await;
 
         let outcomes = match submit {
@@ -574,7 +594,9 @@ impl Planner {
             .iter()
             .map(|(b, r)| format!("{b}={:?}", r))
             .collect();
-        let any_invalidated = outcomes.iter().any(|(_, r)| matches!(r, rulake::RefreshResult::Invalidated));
+        let any_invalidated = outcomes
+            .iter()
+            .any(|(_, r)| matches!(r, rulake::RefreshResult::Invalidated));
         let reason_code = if any_invalidated {
             ReasonCode::StaleCacheRemoteValid
         } else {
@@ -619,7 +641,7 @@ impl Planner {
             .ok_or_else(|| PlanError::Internal("intent=verify requires `verify` block".into()))?;
         let routes = match self.resolve_routes(&req.target, req.budget.max_backends as usize) {
             Ok(r) => r,
-            Err(PlanError::Refused(resp)) => return Ok(resp),
+            Err(PlanError::Refused(resp)) => return Ok(*resp),
             Err(e) => return Err(e),
         };
         if routes.is_empty() {
@@ -627,7 +649,10 @@ impl Planner {
                 "verify",
                 "no allowed routes",
                 ReasonCode::PolicyRefusedAllowlist,
-                vec![], vec![], start, req.budget.max_latency_ms,
+                vec![],
+                vec![],
+                start,
+                req.budget.max_latency_ms,
             ));
         }
 
@@ -669,9 +694,9 @@ impl Planner {
                     rulake::RuLakeBundle::read_from_dir(&dir)?
                 };
                 let recomputed_ok = bundle.verify_witness();
-                let cache_witness = routes_for_run.first().and_then(|(b, c)| {
-                    lake.cache_witness_of(&(b.clone(), c.clone()))
-                });
+                let cache_witness = routes_for_run
+                    .first()
+                    .and_then(|(b, c)| lake.cache_witness_of(&(b.clone(), c.clone())));
                 let matches_cache = cache_witness.as_deref() == Some(bundle.rvf_witness.as_str());
                 Ok(VerifyOutcome {
                     disk_witness: bundle.rvf_witness.clone(),
@@ -725,8 +750,7 @@ impl Planner {
         } else {
             ReasonCode::StaleCacheRemoteValid
         };
-        let backends_planned: Vec<String> =
-            routes.iter().map(|(b, _)| b.clone()).collect();
+        let backends_planned: Vec<String> = routes.iter().map(|(b, _)| b.clone()).collect();
         Ok(QueryResponse {
             data: vec![], // verify has no row data; only metadata
             provenance: Provenance {
@@ -744,7 +768,11 @@ impl Planner {
                 reason: format!(
                     "disk witness {} ({}); cache witness {}",
                     outcome.disk_witness,
-                    if outcome.recomputed_ok { "valid" } else { "INVALID" },
+                    if outcome.recomputed_ok {
+                        "valid"
+                    } else {
+                        "INVALID"
+                    },
                     outcome.cache_witness.as_deref().unwrap_or("absent"),
                 ),
                 backends_planned: backends_planned.clone(),
@@ -774,7 +802,7 @@ impl Planner {
         let entry_count = self.lake.cache_entry_count();
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-        let lines = vec![
+        let lines = [
             format!(
                 "cache: hits={} misses={} primes={} hit_rate={:.3}",
                 stats.hits,
@@ -820,6 +848,7 @@ impl Planner {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_refusal_intent(
         &self,
         intent: &str,
@@ -830,7 +859,14 @@ impl Planner {
         start: std::time::Instant,
         budget_cap_ms: u64,
     ) -> QueryResponse {
-        let mut r = self.build_refusal(reason, code, backends_planned, refusals, start, budget_cap_ms);
+        let mut r = self.build_refusal(
+            reason,
+            code,
+            backends_planned,
+            refusals,
+            start,
+            budget_cap_ms,
+        );
         r.decision.intent = intent.to_string();
         r
     }
@@ -864,11 +900,9 @@ impl Planner {
                 500,
                 vec!["wait".into(), "narrow_target".into()],
             ),
-            BackpressureReason::RateLimitProcess => (
-                "rate_limit_process".into(),
-                1000,
-                vec!["wait".into()],
-            ),
+            BackpressureReason::RateLimitProcess => {
+                ("rate_limit_process".into(), 1000, vec!["wait".into()])
+            }
             BackpressureReason::BudgetExceeded => (
                 "budget_exceeded".into(),
                 0,
@@ -926,7 +960,7 @@ impl Planner {
         // ADR-004 §4a, NOT an error.
         let routes = match self.resolve_routes(&req.target, req.budget.max_backends as usize) {
             Ok(r) => r,
-            Err(PlanError::Refused(resp)) => return Ok(resp),
+            Err(PlanError::Refused(resp)) => return Ok(*resp),
             Err(e) => return Err(e),
         };
         if routes.is_empty() {
@@ -976,22 +1010,17 @@ impl Planner {
             set.dedup();
             set
         };
-        let backends_planned: Vec<String> =
-            routes.iter().map(|(b, _)| b.clone()).collect();
+        let backends_planned: Vec<String> = routes.iter().map(|(b, _)| b.clone()).collect();
 
         // v0.1 doesn't actually verify witnesses on the search path —
         // that's plumbed via Consistency in the Rust crate. trust_level
         // therefore reflects what Consistency was configured to do.
         let witness = if let Some((b, c)) = routes.first() {
-            self.lake
-                .cache_witness_of(&(b.clone(), c.clone()))
+            self.lake.cache_witness_of(&(b.clone(), c.clone()))
         } else {
             None
         };
-        let witness_verified = matches!(
-            self.consistency_label.as_str(),
-            "Fresh" | "Frozen"
-        );
+        let witness_verified = matches!(self.consistency_label.as_str(), "Fresh" | "Frozen");
         let trust_level = if policy.witness_required && !witness_verified {
             // ADR-004 precedence: witness > freshness > budget. Refusal
             // is a successful planner outcome (Ok), not a PlanError.
@@ -1089,7 +1118,7 @@ impl Planner {
         // 1. Backend must be registered.
         for (b, _) in &routes {
             if !self.backend_ids.contains(b) {
-                return Err(PlanError::Refused(self.build_refusal(
+                return Err(PlanError::Refused(Box::new(self.build_refusal(
                     &format!("backend {b:?} not registered"),
                     ReasonCode::PolicyRefusedAllowlist,
                     vec![b.clone()],
@@ -1099,7 +1128,7 @@ impl Planner {
                     }],
                     std::time::Instant::now(),
                     100,
-                )));
+                ))));
             }
         }
 
@@ -1123,14 +1152,14 @@ impl Planner {
                     routes.len(),
                     required_cap.label(),
                 );
-                return Err(PlanError::Refused(self.build_refusal(
+                return Err(PlanError::Refused(Box::new(self.build_refusal(
                     &msg,
                     ReasonCode::PolicyRefusedAllowlist,
                     backends,
                     refusals,
                     std::time::Instant::now(),
                     100,
-                )));
+                ))));
             }
         }
         Ok(routes)

--- a/crates/mcp-server/src/policy.rs
+++ b/crates/mcp-server/src/policy.rs
@@ -3,11 +3,11 @@
 //! The four tiers from ADR-004 §4b:
 //! - `read`     — default; exposes `rulake_query` (and `rulake_list_backends`)
 //! - `internal` — operator-only (no OAuth scope); exposes the internal
-//!                kernel tools that `rulake_query` composes
+//!   kernel tools that `rulake_query` composes
 //! - `publish`  — adds `rulake_publish_bundle` + `rulake_refresh_from_bundle_dir`
-//!                + enables `intent: "refresh"`
+//!   + enables `intent: "refresh"`
 //! - `admin`    — adds `rulake_save_cache_to_dir` + `rulake_warm_from_dir` +
-//!                `rulake_invalidate_cache`
+//!   `rulake_invalidate_cache`
 //!
 //! v0.3 enforces capability membership at tool-call time. OAuth-scope
 //! mapping (mcp:rulake:read|publish|admin) lands in v0.4 with the
@@ -61,7 +61,9 @@ impl Capability {
             "internal" => Ok(Self::Internal),
             "publish" => Ok(Self::Publish),
             "admin" => Ok(Self::Admin),
-            other => anyhow::bail!("unknown capability {other:?} — expected read|internal|publish|admin"),
+            other => {
+                anyhow::bail!("unknown capability {other:?} — expected read|internal|publish|admin")
+            }
         }
     }
 }

--- a/crates/mcp-server/src/ratelimit.rs
+++ b/crates/mcp-server/src/ratelimit.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use dashmap::DashMap;
-use governor::{Quota, RateLimiter, clock::DefaultClock, state::keyed::DefaultKeyedStateStore};
+use governor::{clock::DefaultClock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
 
 /// Configuration for one rate-limit layer. Defaults match ADR-004 §6.
 #[derive(Debug, Clone, Copy)]
@@ -58,9 +58,18 @@ struct Inner {
 impl Default for LayeredRateLimiter {
     fn default() -> Self {
         Self::new(
-            LayerConfig { per_second: 60, burst: 120 },
-            LayerConfig { per_second: 30, burst: 60 },
-            LayerConfig { per_second: 600, burst: 1200 },
+            LayerConfig {
+                per_second: 60,
+                burst: 120,
+            },
+            LayerConfig {
+                per_second: 30,
+                burst: 60,
+            },
+            LayerConfig {
+                per_second: 600,
+                burst: 1200,
+            },
         )
     }
 }
@@ -104,7 +113,9 @@ impl LayeredRateLimiter {
             return RateLimitDecision::Denied { layer: "principal" };
         }
         if self.inner.per_collection.check_key(&key_c).is_err() {
-            return RateLimitDecision::Denied { layer: "collection" };
+            return RateLimitDecision::Denied {
+                layer: "collection",
+            };
         }
         RateLimitDecision::Allowed
     }
@@ -131,7 +142,9 @@ pub enum RateLimitDecision {
     Allowed,
     /// `layer` ∈ {"process", "principal", "collection"} — matches the
     /// audit `decision.refusals[].code` taxonomy.
-    Denied { layer: &'static str },
+    Denied {
+        layer: &'static str,
+    },
 }
 
 #[cfg(test)]
@@ -142,22 +155,37 @@ mod tests {
     fn allows_under_burst() {
         let rl = LayeredRateLimiter::default();
         for _ in 0..10 {
-            assert_eq!(rl.check("stdio", "alice", "be", "docs"), RateLimitDecision::Allowed);
+            assert_eq!(
+                rl.check("stdio", "alice", "be", "docs"),
+                RateLimitDecision::Allowed
+            );
         }
     }
 
     #[test]
     fn isolates_principals() {
         let rl = LayeredRateLimiter::new(
-            LayerConfig { per_second: 1, burst: 2 },
-            LayerConfig { per_second: 100, burst: 200 },
-            LayerConfig { per_second: 1000, burst: 2000 },
+            LayerConfig {
+                per_second: 1,
+                burst: 2,
+            },
+            LayerConfig {
+                per_second: 100,
+                burst: 200,
+            },
+            LayerConfig {
+                per_second: 1000,
+                burst: 2000,
+            },
         );
         // Burn alice's bucket.
         rl.check("h", "alice", "be", "x");
         rl.check("h", "alice", "be", "x");
         let alice_third = rl.check("h", "alice", "be", "x");
-        assert!(matches!(alice_third, RateLimitDecision::Denied { layer: "principal" }));
+        assert!(matches!(
+            alice_third,
+            RateLimitDecision::Denied { layer: "principal" }
+        ));
         // Bob is unaffected.
         let bob = rl.check("h", "bob", "be", "x");
         assert_eq!(bob, RateLimitDecision::Allowed);

--- a/crates/mcp-server/src/replay.rs
+++ b/crates/mcp-server/src/replay.rs
@@ -2,8 +2,8 @@
 //!
 //! Per-request `MCP-Request-Id` nonce dedup over a 10k-entry LRU
 //! window. Replays inside that window are rejected; OAuth signature
-//! + audience + short expiry handles the bulk of the threat, this
-//! is the same-window second-strike layer.
+//! + audience + short expiry handles the bulk of the threat, and
+//!   this is the same-window second-strike layer.
 //!
 //! Session-id binding to `(principal, client_id, mTLS-cert)` is also
 //! per ADR-004 §5; we surface the binding hash so the HTTP layer can

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -9,8 +9,6 @@
 use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError,
-    ServerHandler, ServiceExt,
     handler::server::{
         router::tool::ToolRouter,
         wrapper::{Json, Parameters},
@@ -21,14 +19,14 @@ use rmcp::{
         ServerInfo,
     },
     service::RequestContext,
-    tool, tool_handler, tool_router,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
 
-use rulake::{LocalBackend, RuLake, BackendAdapter, FsBackend};
+use rulake::{BackendAdapter, FsBackend, LocalBackend, RuLake};
 
 use crate::allow::AllowList;
-use crate::audit::{AuditEntry, AuditSink, PolicyDecision, now_ts};
+use crate::audit::{now_ts, AuditEntry, AuditSink, PolicyDecision};
 use crate::config::{AllowBlock, BackendConfig, McpConfig};
 use crate::planner::{DecisionTrace, PlanError, Planner, QueryRequest, TracedQueryResponse};
 use crate::policy::{Capability, CapabilitySet};
@@ -63,8 +61,8 @@ impl RuLakeMcpServer {
         let consistency = config.consistency.into_runtime();
         let consistency_label = format!("{consistency:?}");
 
-        let lake = RuLake::new(config.rerank_factor, config.rotation_seed)
-            .with_consistency(consistency);
+        let lake =
+            RuLake::new(config.rerank_factor, config.rotation_seed).with_consistency(consistency);
 
         let mut backend_ids = Vec::with_capacity(config.backends.len() + 1);
 
@@ -118,7 +116,11 @@ impl RuLakeMcpServer {
                         .map_err(|e| anyhow::anyhow!("register {id}: {e}"))?;
                     backend_ids.push(id.clone());
                 }
-                BackendConfig::Fs { id, root, collections } => {
+                BackendConfig::Fs {
+                    id,
+                    root,
+                    collections,
+                } => {
                     let fs = FsBackend::new(id.clone(), root)
                         .map_err(|e| anyhow::anyhow!("fs {id}: {e}"))?;
                     for c in collections {
@@ -249,7 +251,12 @@ impl RuLakeMcpServer {
         let freshness_budget_ms = req.budget.max_latency_ms;
         let result = self.planner.handle(req).await;
         let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-        let cap_grant = self.capabilities.labels().iter().map(|s| s.to_string()).collect();
+        let cap_grant = self
+            .capabilities
+            .labels()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         match result {
             Ok(resp) => {
                 let outcome = if resp.data.is_empty()
@@ -286,7 +293,10 @@ impl RuLakeMcpServer {
                     freshness_budget_ms,
                     elapsed_ms,
                 );
-                Ok(Json(TracedQueryResponse { inner: resp, decision_trace: trace }))
+                Ok(Json(TracedQueryResponse {
+                    inner: resp,
+                    decision_trace: trace,
+                }))
             }
             Err(PlanError::Refused(resp)) => {
                 self.audit.emit(AuditEntry {
@@ -316,7 +326,10 @@ impl RuLakeMcpServer {
                     freshness_budget_ms,
                     elapsed_ms,
                 );
-                Ok(Json(TracedQueryResponse { inner: resp, decision_trace: trace }))
+                Ok(Json(TracedQueryResponse {
+                    inner: *resp,
+                    decision_trace: trace,
+                }))
             }
             Err(PlanError::Degraded { inflight, cap }) => {
                 self.audit.emit(AuditEntry {
@@ -367,7 +380,10 @@ impl RuLakeMcpServer {
                     }),
                     decision: None,
                 });
-                Err(McpError::internal_error(format!("RULAKE_INTERNAL: {s}"), None))
+                Err(McpError::internal_error(
+                    format!("RULAKE_INTERNAL: {s}"),
+                    None,
+                ))
             }
         }
     }
@@ -438,7 +454,10 @@ impl RuLakeMcpServer {
             let res = self
                 .planner
                 .workers
-                .submit(move || lake.publish_bundle(&key, &dir).map(|p| p.to_string_lossy().to_string()))
+                .submit(move || {
+                    lake.publish_bundle(&key, &dir)
+                        .map(|p| p.to_string_lossy().to_string())
+                })
                 .await
                 .map_err(|e| McpError::internal_error(format!("RULAKE_DEGRADED: {e}"), None))?
                 .map_err(|e| McpError::internal_error(format!("RULAKE_INTERNAL: {e}"), None))?;
@@ -484,7 +503,9 @@ impl RuLakeMcpServer {
                 rulake::RefreshResult::Invalidated => "invalidated",
                 rulake::RefreshResult::BundleMissing => "bundle_missing",
             };
-            Ok(Json(RefreshResponse { status: status.into() }))
+            Ok(Json(RefreshResponse {
+                status: status.into(),
+            }))
         }
         .await;
         self.audit_mutation(
@@ -519,7 +540,10 @@ impl RuLakeMcpServer {
             let res = self
                 .planner
                 .workers
-                .submit(move || lake.save_cache_to_dir(&key, &dir).map(|p| p.to_string_lossy().to_string()))
+                .submit(move || {
+                    lake.save_cache_to_dir(&key, &dir)
+                        .map(|p| p.to_string_lossy().to_string())
+                })
                 .await
                 .map_err(|e| McpError::internal_error(format!("RULAKE_DEGRADED: {e}"), None))?
                 .map_err(|e| McpError::internal_error(format!("RULAKE_INTERNAL: {e}"), None))?;
@@ -560,7 +584,9 @@ impl RuLakeMcpServer {
                 .await
                 .map_err(|e| McpError::internal_error(format!("RULAKE_DEGRADED: {e}"), None))?
                 .map_err(|e| McpError::internal_error(format!("RULAKE_INTERNAL: {e}"), None))?;
-            Ok(Json(WarmResponse { vectors: res as u32 }))
+            Ok(Json(WarmResponse {
+                vectors: res as u32,
+            }))
         }
         .await;
         self.audit_mutation(
@@ -676,9 +702,9 @@ fn required_cap_for_tool(name: &str) -> Capability {
         "rulake_query" | "rulake_list_backends" | "rulake_list_collections" => Capability::Read,
         // Mutation tools — publish/admin tiers.
         "rulake_publish_bundle" | "rulake_refresh_from_bundle_dir" => Capability::Publish,
-        "rulake_save_cache_to_dir"
-        | "rulake_warm_from_dir"
-        | "rulake_invalidate_cache" => Capability::Admin,
+        "rulake_save_cache_to_dir" | "rulake_warm_from_dir" | "rulake_invalidate_cache" => {
+            Capability::Admin
+        }
         // Anything else (future internal-kernel tools etc.) defaults
         // to internal — invisible by default until --capabilities
         // internal is granted. Safer than defaulting to Read.
@@ -815,8 +841,10 @@ impl ServerHandler for RuLakeMcpServer {
             .into_iter()
             .filter(|t| effective.has(required_cap_for_tool(&t.name)))
             .collect();
-        let mut result = ListToolsResult::default();
-        result.tools = tools;
+        let result = ListToolsResult {
+            tools,
+            ..ListToolsResult::default()
+        };
         Ok(result)
     }
 
@@ -840,8 +868,10 @@ impl ServerHandler for RuLakeMcpServer {
                 rmcp::model::Annotated::new(r, None)
             },
             {
-                let mut r = RawResource::new("rulake://stats/by-backend", "cache stats per backend");
-                r.description = Some("Per-backend cache stats: hits/misses/primes per backend id.".into());
+                let mut r =
+                    RawResource::new("rulake://stats/by-backend", "cache stats per backend");
+                r.description =
+                    Some("Per-backend cache stats: hits/misses/primes per backend id.".into());
                 r.mime_type = Some("application/json".into());
                 rmcp::model::Annotated::new(r, None)
             },
@@ -879,9 +909,9 @@ impl ServerHandler for RuLakeMcpServer {
         params: ReadResourceRequestParams,
         _context: RequestContext<rmcp::service::RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        let body = self.read_resource_json(&params.uri).map_err(|e| {
-            McpError::invalid_params(format!("RULAKE_RESOURCE: {e}"), None)
-        })?;
+        let body = self
+            .read_resource_json(&params.uri)
+            .map_err(|e| McpError::invalid_params(format!("RULAKE_RESOURCE: {e}"), None))?;
         let contents = ResourceContents::text(body, params.uri);
         Ok(ReadResourceResult::new(vec![contents]))
     }
@@ -967,4 +997,3 @@ impl RuLakeMcpServer {
         }
     }
 }
-

--- a/crates/mcp-server/src/sessions.rs
+++ b/crates/mcp-server/src/sessions.rs
@@ -69,7 +69,9 @@ impl SessionBindings {
     ) -> SessionDecision {
         if session_id.is_empty() {
             // No session id (initialize call etc.) — pass through.
-            return SessionDecision::Allowed { first_sighting: false };
+            return SessionDecision::Allowed {
+                first_sighting: false,
+            };
         }
         let want = BindingTuple {
             principal: principal.to_string(),
@@ -79,7 +81,9 @@ impl SessionBindings {
         let mut inner = self.inner.lock().unwrap();
         if let Some(existing) = inner.bindings.get(session_id) {
             if existing == &want {
-                return SessionDecision::Allowed { first_sighting: false };
+                return SessionDecision::Allowed {
+                    first_sighting: false,
+                };
             }
             return SessionDecision::Mismatch {
                 expected_principal: existing.principal.clone(),
@@ -94,7 +98,9 @@ impl SessionBindings {
         }
         inner.seen.push_back(session_id.to_string());
         inner.bindings.insert(session_id.to_string(), want);
-        SessionDecision::Allowed { first_sighting: true }
+        SessionDecision::Allowed {
+            first_sighting: true,
+        }
     }
 
     pub fn binding_count(&self) -> usize {
@@ -123,14 +129,24 @@ mod tests {
     fn empty_session_id_passes() {
         let s = SessionBindings::new();
         let d = s.check_or_bind("", "alice", None, None);
-        assert_eq!(d, SessionDecision::Allowed { first_sighting: false });
+        assert_eq!(
+            d,
+            SessionDecision::Allowed {
+                first_sighting: false
+            }
+        );
     }
 
     #[test]
     fn first_sighting_records_binding() {
         let s = SessionBindings::new();
         let d = s.check_or_bind("sess-1", "alice", Some("cursor"), None);
-        assert_eq!(d, SessionDecision::Allowed { first_sighting: true });
+        assert_eq!(
+            d,
+            SessionDecision::Allowed {
+                first_sighting: true
+            }
+        );
         assert_eq!(s.binding_count(), 1);
     }
 
@@ -139,7 +155,12 @@ mod tests {
         let s = SessionBindings::new();
         s.check_or_bind("sess-1", "alice", Some("cursor"), None);
         let d = s.check_or_bind("sess-1", "alice", Some("cursor"), None);
-        assert_eq!(d, SessionDecision::Allowed { first_sighting: false });
+        assert_eq!(
+            d,
+            SessionDecision::Allowed {
+                first_sighting: false
+            }
+        );
     }
 
     #[test]
@@ -148,7 +169,10 @@ mod tests {
         s.check_or_bind("sess-1", "alice", Some("cursor"), None);
         let d = s.check_or_bind("sess-1", "mallory", Some("cursor"), None);
         match d {
-            SessionDecision::Mismatch { expected_principal, presented_principal } => {
+            SessionDecision::Mismatch {
+                expected_principal,
+                presented_principal,
+            } => {
                 assert_eq!(expected_principal, "alice");
                 assert_eq!(presented_principal, "mallory");
             }
@@ -181,6 +205,11 @@ mod tests {
         assert_eq!(s.binding_count(), WINDOW);
         // The first session aged out — re-binding it counts as first sighting.
         let d = s.check_or_bind("sess-0", "u", None, None);
-        assert_eq!(d, SessionDecision::Allowed { first_sighting: true });
+        assert_eq!(
+            d,
+            SessionDecision::Allowed {
+                first_sighting: true
+            }
+        );
     }
 }

--- a/crates/mcp-server/src/workers.rs
+++ b/crates/mcp-server/src/workers.rs
@@ -103,7 +103,9 @@ impl WorkerPool {
     }
 
     pub fn inflight(&self) -> usize {
-        self.inner.inflight.load(std::sync::atomic::Ordering::Relaxed)
+        self.inner
+            .inflight
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn max_inflight(&self) -> usize {

--- a/crates/mcp-server/tests/demo_backend.rs
+++ b/crates/mcp-server/tests/demo_backend.rs
@@ -13,8 +13,10 @@ use ruvector_rulake_mcp::{config::McpConfig, server::RuLakeMcpServer};
 
 #[test]
 fn demo_backend_registers_seeded_collection_and_allow_block() {
-    let mut cfg = McpConfig::default();
-    cfg.demo_backend = true;
+    let cfg = McpConfig {
+        demo_backend: true,
+        ..McpConfig::default()
+    };
     // Construct should succeed — the seeded LocalBackend is wired in.
     let _server = RuLakeMcpServer::new(cfg).expect("build server with demo_backend = true");
     // Successful construction is the assertion. The path that registers
@@ -26,6 +28,9 @@ fn demo_backend_registers_seeded_collection_and_allow_block() {
 #[test]
 fn demo_backend_off_by_default() {
     let cfg = McpConfig::default();
-    assert!(!cfg.demo_backend, "production deploys must opt in explicitly");
+    assert!(
+        !cfg.demo_backend,
+        "production deploys must opt in explicitly"
+    );
     let _server = RuLakeMcpServer::new(cfg).expect("default-config server still constructs");
 }

--- a/crates/mcp-server/tests/http_e2e.rs
+++ b/crates/mcp-server/tests/http_e2e.rs
@@ -14,7 +14,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use rulake::{LocalBackend, RuLake, BackendAdapter};
+use rulake::{BackendAdapter, LocalBackend, RuLake};
 use ruvector_rulake_mcp::{
     AllowBearerOnPublic, AuthMode, BearerAuth, InsecureAllowNoAuth, RuLakeMcpServer,
 };
@@ -31,13 +31,7 @@ fn make_server() -> RuLakeMcpServer {
     .unwrap();
     let dyn_be: Arc<dyn BackendAdapter> = be;
     lake.register_backend(dyn_be).unwrap();
-    RuLakeMcpServer::from_lake(
-        Arc::new(lake),
-        "Fresh".into(),
-        vec!["local".into()],
-        64,
-    )
-    .unwrap()
+    RuLakeMcpServer::from_lake(Arc::new(lake), "Fresh".into(), vec!["local".into()], 64).unwrap()
 }
 
 #[tokio::test]
@@ -69,7 +63,9 @@ async fn http_serve_starts_on_loopback_with_no_auth() {
     // listener accepting at all proves the transport is up.
     let mut conn = tokio::net::TcpStream::connect(bind).await.unwrap();
     use tokio::io::AsyncWriteExt;
-    conn.write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n").await.unwrap();
+    conn.write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
     use tokio::io::AsyncReadExt;
     let mut buf = vec![0u8; 4096];
     let n = tokio::time::timeout(Duration::from_secs(2), conn.read(&mut buf))
@@ -152,10 +148,7 @@ async fn bearer_auth_rejects_wrong_token() {
     use http::HeaderMap;
     let bearer = BearerAuth::new("right");
     let mut headers = HeaderMap::new();
-    headers.insert(
-        http::header::AUTHORIZATION,
-        "Bearer wrong".parse().unwrap(),
-    );
+    headers.insert(http::header::AUTHORIZATION, "Bearer wrong".parse().unwrap());
     let err = bearer.verify(&headers).unwrap_err();
     assert_eq!(err, http::StatusCode::UNAUTHORIZED);
 }
@@ -200,7 +193,10 @@ async fn cors_preflight_returns_204_with_browser_friendly_headers() {
 
     let client = reqwest::Client::new();
     let resp = client
-        .request(reqwest::Method::OPTIONS, format!("http://127.0.0.1:{port}/"))
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://127.0.0.1:{port}/"),
+        )
         .header("Origin", "http://127.0.0.1:4173")
         .header("Access-Control-Request-Method", "POST")
         .header(
@@ -277,7 +273,7 @@ async fn cors_preflight_returns_204_with_browser_friendly_headers() {
 #[ignore = "rmcp Streamable HTTP SSE response stays open on keepalives; needs a proper SSE consumer to read the tools/list result. Contract verified by tools_list_filtered_by_capability_set."]
 #[tokio::test(flavor = "multi_thread")]
 async fn jwt_scope_downgrade_filters_tools_list_on_the_wire() {
-    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
     use ruvector_rulake_mcp::auth::JwtKey;
     use ruvector_rulake_mcp::{
         AllowBearerOnPublic, CapabilitySet, InsecureAllowNoAuth, JwtAuth, JwtConfig,
@@ -440,8 +436,8 @@ async fn jwt_scope_downgrade_filters_tools_list_on_the_wire() {
                 .lines()
                 .find_map(|l| l.strip_prefix("data: "))
                 .unwrap_or(body.as_str());
-            let v: serde_json::Value = serde_json::from_str(json_str)
-                .unwrap_or_else(|_| serde_json::json!({}));
+            let v: serde_json::Value =
+                serde_json::from_str(json_str).unwrap_or_else(|_| serde_json::json!({}));
             v.get("result")
                 .and_then(|r| r.get("tools"))
                 .and_then(|t| t.as_array())
@@ -479,7 +475,7 @@ fn make_admin_server() -> ruvector_rulake_mcp::RuLakeMcpServer {
 }
 
 fn make_lake() -> rulake::RuLake {
-    use rulake::{LocalBackend, RuLake, BackendAdapter};
+    use rulake::{BackendAdapter, LocalBackend, RuLake};
     let lake = RuLake::new(20, 42);
     let be = std::sync::Arc::new(LocalBackend::new("local"));
     be.put_collection(

--- a/crates/mcp-server/tests/smoke.rs
+++ b/crates/mcp-server/tests/smoke.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use rulake::{LocalBackend, RuLake, BackendAdapter};
+use rulake::{BackendAdapter, LocalBackend, RuLake};
 use ruvector_rulake_mcp::RuLakeMcpServer;
 
 /// Build an in-memory ruLake with one collection of N×D vectors.
@@ -61,7 +61,7 @@ async fn search_one_returns_top_k_via_planner() {
     assert_eq!(resp.data[0].id, "42", "top-1 must be the self-vector");
     assert_eq!(resp.decision.chosen_action, "search_one");
     assert_eq!(resp.decision.backends_used, vec!["local".to_string()]);
-    assert_eq!(resp.decision.degraded, false);
+    assert!(!resp.decision.degraded);
     assert!(resp.decision.budget_used_ms >= 0.0);
 }
 
@@ -82,7 +82,11 @@ async fn refuses_on_unknown_backend_with_policy_refused_allowlist() {
         "search": { "vector": vectors[0], "k": 3 }
     });
     let req = serde_json::from_value(request).unwrap();
-    let resp = server.planner().handle(req).await.expect("planner returns refusal as Ok");
+    let resp = server
+        .planner()
+        .handle(req)
+        .await
+        .expect("planner returns refusal as Ok");
 
     // Refusal is a successful planner response with empty data + reason_code.
     assert!(resp.data.is_empty(), "refused → empty data");
@@ -137,7 +141,11 @@ async fn backpressure_response_carries_advice_block() {
     );
     assert!(resp.data.is_empty(), "degraded → empty data");
     assert!(resp.decision.degraded, "decision.degraded = true");
-    let advice = resp.decision.degraded_advice.as_ref().expect("advice block present");
+    let advice = resp
+        .decision
+        .degraded_advice
+        .as_ref()
+        .expect("advice block present");
     assert_eq!(advice.reason, "rate_limit_collection");
     assert!(advice.retry_after_ms > 0);
     assert!(
@@ -160,7 +168,10 @@ async fn backpressure_inflight_cap_carries_inflight_numbers() {
     .unwrap();
     let resp = server.planner().build_degraded_response(
         "search",
-        BackpressureReason::InflightCap { inflight: 64, cap: 64 },
+        BackpressureReason::InflightCap {
+            inflight: 64,
+            cap: 64,
+        },
         100,
     );
     assert!(resp.decision.degraded);
@@ -173,7 +184,7 @@ async fn backpressure_inflight_cap_carries_inflight_numbers() {
 
 #[tokio::test]
 async fn tools_list_filtered_by_capability_set() {
-    use rulake::{LocalBackend, RuLake, BackendAdapter};
+    use rulake::{BackendAdapter, LocalBackend, RuLake};
     use ruvector_rulake_mcp::CapabilitySet;
 
     let lake = RuLake::new(20, 42);
@@ -195,7 +206,11 @@ async fn tools_list_filtered_by_capability_set() {
     // v0.9 added rulake_list_collections — also a Read-tier tool.
     assert_eq!(
         names,
-        vec!["rulake_list_backends", "rulake_list_collections", "rulake_query"],
+        vec![
+            "rulake_list_backends",
+            "rulake_list_collections",
+            "rulake_query"
+        ],
     );
 
     // read,publish: + 2 publish tools.
@@ -210,7 +225,10 @@ async fn tools_list_filtered_by_capability_set() {
     let names = list_tool_names_via_handler(&publish).await;
     assert!(names.contains(&"rulake_publish_bundle".to_string()));
     assert!(names.contains(&"rulake_refresh_from_bundle_dir".to_string()));
-    assert!(!names.contains(&"rulake_invalidate_cache".to_string()), "admin tool must stay hidden");
+    assert!(
+        !names.contains(&"rulake_invalidate_cache".to_string()),
+        "admin tool must stay hidden"
+    );
 
     // read,publish,admin: all 7.
     let admin = RuLakeMcpServer::from_lake_with_caps(
@@ -224,9 +242,13 @@ async fn tools_list_filtered_by_capability_set() {
     let names = list_tool_names_via_handler(&admin).await;
     assert_eq!(names.len(), 8, "admin sees all 8 tools, got {names:?}");
     for required in &[
-        "rulake_query", "rulake_list_backends", "rulake_list_collections",
-        "rulake_publish_bundle", "rulake_refresh_from_bundle_dir",
-        "rulake_save_cache_to_dir", "rulake_warm_from_dir",
+        "rulake_query",
+        "rulake_list_backends",
+        "rulake_list_collections",
+        "rulake_publish_bundle",
+        "rulake_refresh_from_bundle_dir",
+        "rulake_save_cache_to_dir",
+        "rulake_warm_from_dir",
         "rulake_invalidate_cache",
     ] {
         assert!(names.iter().any(|n| n == required), "missing {required}");
@@ -244,16 +266,18 @@ async fn tools_list_filtered_by_capability_set() {
 
 #[tokio::test]
 async fn rbac_denies_unallowed_collection() {
-    use rulake::{LocalBackend, RuLake, BackendAdapter};
-    use ruvector_rulake_mcp::AllowList;
+    use rulake::{BackendAdapter, LocalBackend, RuLake};
     use ruvector_rulake_mcp::config::AllowBlock;
     use ruvector_rulake_mcp::planner::Planner;
+    use ruvector_rulake_mcp::AllowList;
     use ruvector_rulake_mcp::WorkerPool;
 
     let lake = RuLake::new(20, 42);
     let be = std::sync::Arc::new(LocalBackend::new("local"));
-    be.put_collection("docs", 8, vec![0u64], vec![vec![0.0_f32; 8]]).unwrap();
-    be.put_collection("secret", 8, vec![0u64], vec![vec![0.0_f32; 8]]).unwrap();
+    be.put_collection("docs", 8, vec![0u64], vec![vec![0.0_f32; 8]])
+        .unwrap();
+    be.put_collection("secret", 8, vec![0u64], vec![vec![0.0_f32; 8]])
+        .unwrap();
     let dyn_be: std::sync::Arc<dyn BackendAdapter> = be;
     lake.register_backend(dyn_be).unwrap();
 
@@ -292,7 +316,10 @@ async fn rbac_denies_unallowed_collection() {
         "search": { "vector": vec![0.0_f32; 8], "k": 1 }
     }))
     .unwrap();
-    let r2 = planner.handle(req_denied).await.expect("planner returns refusal as Ok");
+    let r2 = planner
+        .handle(req_denied)
+        .await
+        .expect("planner returns refusal as Ok");
     assert!(r2.data.is_empty(), "denied route → empty data");
     let code = format!("{:?}", r2.decision.reason_code);
     assert!(
@@ -300,7 +327,10 @@ async fn rbac_denies_unallowed_collection() {
         "expected PolicyRefusedAllowlist, got {code}"
     );
     assert!(
-        r2.decision.refusals.iter().any(|r| r.code.contains("ALLOWLIST_DENIED")),
+        r2.decision
+            .refusals
+            .iter()
+            .any(|r| r.code.contains("ALLOWLIST_DENIED")),
         "refusals must name the rule that denied"
     );
 }
@@ -315,7 +345,10 @@ async fn capability_intersect_keeps_only_both_grants() {
     let effective = server.intersect(&token);
     assert!(effective.has(Capability::Read));
     assert!(effective.has(Capability::Publish));
-    assert!(!effective.has(Capability::Admin), "admin not in token → not in intersection");
+    assert!(
+        !effective.has(Capability::Admin),
+        "admin not in token → not in intersection"
+    );
 }
 
 #[tokio::test]
@@ -330,8 +363,8 @@ async fn capability_intersect_empty_token_yields_empty() {
 
 #[tokio::test]
 async fn effective_caps_falls_through_to_server_wide_when_task_local_unset() {
-    use ruvector_rulake_mcp::{Capability, CapabilitySet};
     use ruvector_rulake_mcp::policy::effective_caps;
+    use ruvector_rulake_mcp::{Capability, CapabilitySet};
     let server = CapabilitySet::from_csv("read,publish").unwrap();
     // Outside any REQUEST_CAPS scope — fall through.
     let effective = effective_caps(&server);
@@ -341,15 +374,20 @@ async fn effective_caps_falls_through_to_server_wide_when_task_local_unset() {
 
 #[tokio::test]
 async fn effective_caps_intersects_inside_task_local_scope() {
+    use ruvector_rulake_mcp::policy::{effective_caps, REQUEST_CAPS};
     use ruvector_rulake_mcp::{Capability, CapabilitySet};
-    use ruvector_rulake_mcp::policy::{REQUEST_CAPS, effective_caps};
     let server = CapabilitySet::from_csv("read,publish,admin").unwrap();
     let token = CapabilitySet::from_csv("read").unwrap();
-    let result = REQUEST_CAPS.scope(token, async move {
-        let effective = effective_caps(&server);
-        effective.has(Capability::Admin)
-    }).await;
-    assert!(!result, "token-restricted scope must downgrade server's admin to read");
+    let result = REQUEST_CAPS
+        .scope(token, async move {
+            let effective = effective_caps(&server);
+            effective.has(Capability::Admin)
+        })
+        .await;
+    assert!(
+        !result,
+        "token-restricted scope must downgrade server's admin to read"
+    );
 }
 
 #[tokio::test]
@@ -366,7 +404,10 @@ async fn capability_set_default_excludes_publish_and_admin() {
 async fn capability_set_publish_implies_read() {
     use ruvector_rulake_mcp::{Capability, CapabilitySet};
     let cs = CapabilitySet::from_csv("publish").unwrap();
-    assert!(cs.has(Capability::Read), "publish must implicitly grant read");
+    assert!(
+        cs.has(Capability::Read),
+        "publish must implicitly grant read"
+    );
     assert!(cs.has(Capability::Publish));
     assert!(!cs.has(Capability::Admin));
 }
@@ -477,13 +518,7 @@ async fn verify_intent_succeeds_on_valid_bundle() {
 
     // Write a fresh bundle to a tempdir.
     let dir = TempDir::new().unwrap();
-    let bundle = RuLakeBundle::new(
-        "test://verify",
-        16,
-        42,
-        20,
-        rulake::Generation::Num(1),
-    );
+    let bundle = RuLakeBundle::new("test://verify", 16, 42, 20, rulake::Generation::Num(1));
     bundle.write_to_dir(dir.path()).unwrap();
 
     let req = serde_json::from_value(serde_json::json!({
@@ -494,10 +529,7 @@ async fn verify_intent_succeeds_on_valid_bundle() {
     .unwrap();
     let resp = server.planner().handle(req).await.expect("ok");
     assert_eq!(resp.decision.intent, "verify");
-    assert!(
-        resp.provenance.witness_verified,
-        "valid bundle must verify"
-    );
+    assert!(resp.provenance.witness_verified, "valid bundle must verify");
     assert_eq!(
         resp.provenance.witness.as_ref().unwrap(),
         &bundle.rvf_witness,

--- a/crates/ruqu-backend/benches/stabilizer.rs
+++ b/crates/ruqu-backend/benches/stabilizer.rs
@@ -89,5 +89,9 @@ fn bench_statevector_for_compare(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_stabilizer_simulate, bench_statevector_for_compare);
+criterion_group!(
+    benches,
+    bench_stabilizer_simulate,
+    bench_statevector_for_compare
+);
 criterion_main!(benches);

--- a/crates/ruqu-backend/benches/tensor_network.rs
+++ b/crates/ruqu-backend/benches/tensor_network.rs
@@ -28,7 +28,10 @@ fn ghz_chain(n_qubits: u8) -> Circuit {
     let mut c = Circuit::new(format!("ghz-{n_qubits}"), n_qubits);
     c.push(Gate::H { q: 0 });
     for i in 0..n_qubits.saturating_sub(1) {
-        c.push(Gate::Cx { control: i, target: i + 1 });
+        c.push(Gate::Cx {
+            control: i,
+            target: i + 1,
+        });
     }
     c
 }
@@ -39,22 +42,34 @@ fn ghz_chain(n_qubits: u8) -> Circuit {
 /// passes so the circuit isn't simulable by Stabilizer.
 fn brickwall_with_t(n_qubits: u8, layers: usize) -> Circuit {
     let mut c = Circuit::new(format!("brick-t-{n_qubits}q-{layers}L"), n_qubits);
-    for q in 0..n_qubits { c.push(Gate::H { q }); }
+    for q in 0..n_qubits {
+        c.push(Gate::H { q });
+    }
     for _ in 0..layers {
         // Even pairs.
         let mut q = 0u8;
         while q + 1 < n_qubits {
-            c.push(Gate::Cx { control: q, target: q + 1 });
+            c.push(Gate::Cx {
+                control: q,
+                target: q + 1,
+            });
             q += 2;
         }
-        for q in 0..n_qubits { c.push(Gate::T { q }); }
+        for q in 0..n_qubits {
+            c.push(Gate::T { q });
+        }
         // Odd pairs.
         let mut q = 1u8;
         while q + 1 < n_qubits {
-            c.push(Gate::Cx { control: q, target: q + 1 });
+            c.push(Gate::Cx {
+                control: q,
+                target: q + 1,
+            });
             q += 2;
         }
-        for q in 0..n_qubits { c.push(Gate::T { q }); }
+        for q in 0..n_qubits {
+            c.push(Gate::T { q });
+        }
     }
     c
 }
@@ -74,8 +89,8 @@ fn bench_ghz_chain(c: &mut Criterion) {
             let id = BenchmarkId::new("ghz_chain", format!("n{n}_chi{chi}"));
             group.bench_with_input(id, &(circuit, chi), |b, (circuit, chi)| {
                 b.iter(|| {
-                    let mps = tensor_network::simulate(circuit, *chi)
-                        .expect("MPS sim must succeed");
+                    let mps =
+                        tensor_network::simulate(circuit, *chi).expect("MPS sim must succeed");
                     criterion::black_box(mps);
                 });
             });
@@ -98,8 +113,8 @@ fn bench_brickwall_with_t(c: &mut Criterion) {
             let id = BenchmarkId::new("brickwall_t", format!("n{n}_chi{chi}_L{layers}"));
             group.bench_with_input(id, &(circuit, chi), |b, (circuit, chi)| {
                 b.iter(|| {
-                    let mps = tensor_network::simulate(circuit, *chi)
-                        .expect("MPS sim must succeed");
+                    let mps =
+                        tensor_network::simulate(circuit, *chi).expect("MPS sim must succeed");
                     criterion::black_box(mps);
                 });
             });

--- a/crates/ruqu-backend/src/circuit.rs
+++ b/crates/ruqu-backend/src/circuit.rs
@@ -79,7 +79,11 @@ pub struct Circuit {
 impl Circuit {
     /// Empty circuit on `n` qubits.
     pub fn new(id: impl Into<String>, n_qubits: u8) -> Self {
-        Self { id: id.into(), n_qubits, gates: Vec::new() }
+        Self {
+            id: id.into(),
+            n_qubits,
+            gates: Vec::new(),
+        }
     }
 
     /// Push a gate. Returns `&mut self` for ergonomic chaining.

--- a/crates/ruqu-backend/src/hardware.rs
+++ b/crates/ruqu-backend/src/hardware.rs
@@ -112,13 +112,19 @@ impl RuquHardwareStubBackend {
     }
 
     /// Borrow the [`HardwareConfig`] currently attached.
-    pub fn config(&self) -> &HardwareConfig { &self.config }
+    pub fn config(&self) -> &HardwareConfig {
+        &self.config
+    }
 
     /// The per-gate depolarising probability the stub will apply.
-    pub fn noise_p(&self) -> f64 { self.noise_p }
+    pub fn noise_p(&self) -> f64 {
+        self.noise_p
+    }
 
     /// The seed pinned at construction.
-    pub fn seed(&self) -> u64 { self.seed }
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
 
     /// Simulate `circuit` through the exact StateVector kernel, apply
     /// the synthetic noise channel, store the (noisy) state under
@@ -168,20 +174,28 @@ impl RuquHardwareStubBackend {
 }
 
 impl BackendAdapter for RuquHardwareStubBackend {
-    fn id(&self) -> &str { &self.id }
+    fn id(&self) -> &str {
+        &self.id
+    }
 
     fn list_collections(&self) -> Result<Vec<CollectionId>> {
-        Ok(self.executions.read().expect("poisoned").keys().cloned().collect())
+        Ok(self
+            .executions
+            .read()
+            .expect("poisoned")
+            .keys()
+            .cloned()
+            .collect())
     }
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(PulledBatch {
             collection: collection.to_string(),
             ids: c.ids.clone(),
@@ -193,12 +207,12 @@ impl BackendAdapter for RuquHardwareStubBackend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(c.generation)
     }
 }
@@ -214,7 +228,9 @@ impl BackendAdapter for RuquHardwareStubBackend {
 /// n_gates)` so two replicas produce identical output.
 fn apply_synthetic_noise(state: &[C], noise_p: f64, seed: u64, n_gates: u64) -> Vec<C> {
     let p_total = 1.0 - (1.0 - noise_p).powi(n_gates as i32);
-    let mut prng = seed.wrapping_add(0x9E37_79B9_7F4A_7C15).wrapping_add(n_gates);
+    let mut prng = seed
+        .wrapping_add(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(n_gates);
     let mut out: Vec<C> = state
         .iter()
         .map(|amp| {
@@ -262,7 +278,10 @@ mod tests {
     fn noise_zero_keeps_unit_norm() {
         let mut c = Circuit::new("bell-hw", 2);
         c.push(Gate::H { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let exact = state_vector::simulate(&c);
         let noisy = apply_synthetic_noise(&exact, 0.0, 7, c.gates.len() as u64);
         let s: f64 = noisy.iter().map(|c| c.re * c.re + c.im * c.im).sum();
@@ -273,7 +292,10 @@ mod tests {
     fn noise_is_deterministic_for_same_seed() {
         let mut c = Circuit::new("bell-hw", 2);
         c.push(Gate::H { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let exact = state_vector::simulate(&c);
         let a = apply_synthetic_noise(&exact, 0.05, 42, c.gates.len() as u64);
         let b = apply_synthetic_noise(&exact, 0.05, 42, c.gates.len() as u64);
@@ -291,8 +313,7 @@ mod tests {
             calibration_tag: Some("2026-04-01".into()),
             runtime_class: Some("session".into()),
         };
-        let be = RuquHardwareStubBackend::new("hw", 0.01, 9)
-            .with_config(cfg);
+        let be = RuquHardwareStubBackend::new("hw", 0.01, 9).with_config(cfg);
         assert_eq!(be.config().provider.as_deref(), Some("ibmq"));
         assert_eq!(be.noise_p(), 0.01);
         assert_eq!(be.seed(), 9);

--- a/crates/ruqu-backend/src/lib.rs
+++ b/crates/ruqu-backend/src/lib.rs
@@ -55,13 +55,9 @@ pub mod witness;
 pub use circuit::{Circuit, Gate};
 pub use hardware::{HardwareConfig, RuquHardwareStubBackend, HARDWARE_STUB_BACKEND_TAG};
 pub use qec::{plan_surface_code, QecError, QecPlan};
-pub use stabilizer::{
-    simulate as simulate_stabilizer, StabilizerError, StabilizerState, Tableau,
-};
+pub use stabilizer::{simulate as simulate_stabilizer, StabilizerError, StabilizerState, Tableau};
 pub use state_vector::{simulate, C};
-pub use tensor_network::{
-    simulate as simulate_tensor_network, Mps, MpsTensor, TensorNetworkError,
-};
+pub use tensor_network::{simulate as simulate_tensor_network, Mps, MpsTensor, TensorNetworkError};
 pub use witness::{inputs_for, ruqu_bundle, RuquWitnessInputs, RuquWitnessInputsOwned};
 
 /// One executed circuit's state, keyed by a "collection name" so it
@@ -91,11 +87,13 @@ impl RuquExecution {
     /// chain (the seed pins the simulation to the same `f64` result).
     pub fn from_state_vector(sv: &[C], generation: u64) -> Self {
         let ids: Vec<u64> = (0..sv.len() as u64).collect();
-        let vectors: Vec<Vec<f32>> = sv
-            .iter()
-            .map(|c| vec![c.re as f32, c.im as f32])
-            .collect();
-        Self { ids, vectors, dim: 2, generation }
+        let vectors: Vec<Vec<f32>> = sv.iter().map(|c| vec![c.re as f32, c.im as f32]).collect();
+        Self {
+            ids,
+            vectors,
+            dim: 2,
+            generation,
+        }
     }
 }
 
@@ -124,12 +122,19 @@ impl RuquStateVectorBackend {
     /// Simulate `circuit` and store the resulting state vector under
     /// `name`. Returns the bundle witness so callers can pin it (or
     /// hand it to a remote replica for byte-equality replay).
-    pub fn execute(&self, name: impl Into<String>, circuit: &Circuit) -> Result<rulake::RuLakeBundle> {
+    pub fn execute(
+        &self,
+        name: impl Into<String>,
+        circuit: &Circuit,
+    ) -> Result<rulake::RuLakeBundle> {
         let sv = state_vector::simulate(circuit);
         let exec = RuquExecution::from_state_vector(&sv, 1);
         let inputs = witness::inputs_for(circuit, "sv", 0, exec.generation);
         let bundle = witness::ruqu_bundle(&inputs.as_borrowed());
-        self.executions.write().expect("poisoned").insert(name.into(), exec);
+        self.executions
+            .write()
+            .expect("poisoned")
+            .insert(name.into(), exec);
         Ok(bundle)
     }
 
@@ -156,17 +161,23 @@ impl BackendAdapter for RuquStateVectorBackend {
     }
 
     fn list_collections(&self) -> Result<Vec<CollectionId>> {
-        Ok(self.executions.read().expect("poisoned").keys().cloned().collect())
+        Ok(self
+            .executions
+            .read()
+            .expect("poisoned")
+            .keys()
+            .cloned()
+            .collect())
     }
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(PulledBatch {
             collection: collection.to_string(),
             ids: c.ids.clone(),
@@ -178,12 +189,12 @@ impl BackendAdapter for RuquStateVectorBackend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(c.generation)
     }
 }
@@ -224,19 +235,26 @@ impl RuquStabilizerBackend {
         name: impl Into<String>,
         circuit: &Circuit,
     ) -> Result<rulake::RuLakeBundle> {
-        let state = stabilizer::simulate(circuit).map_err(|e| {
-            rulake::error::RuLakeError::Backend {
+        let state =
+            stabilizer::simulate(circuit).map_err(|e| rulake::error::RuLakeError::Backend {
                 backend: self.id.clone(),
                 detail: e.to_string(),
-            }
-        })?;
+            })?;
         let vectors = stabilizer::to_pulled_batch_form(&state);
         let dim = vectors.first().map(|v| v.len()).unwrap_or(0);
         let ids: Vec<u64> = (0..vectors.len() as u64).collect();
-        let exec = RuquExecution { ids, vectors, dim, generation: 1 };
+        let exec = RuquExecution {
+            ids,
+            vectors,
+            dim,
+            generation: 1,
+        };
         let inputs = witness::inputs_for(circuit, "stabilizer", 0, exec.generation);
         let bundle = witness::ruqu_bundle(&inputs.as_borrowed());
-        self.executions.write().expect("poisoned").insert(name.into(), exec);
+        self.executions
+            .write()
+            .expect("poisoned")
+            .insert(name.into(), exec);
         Ok(bundle)
     }
 
@@ -258,20 +276,28 @@ impl RuquStabilizerBackend {
 }
 
 impl BackendAdapter for RuquStabilizerBackend {
-    fn id(&self) -> &str { &self.id }
+    fn id(&self) -> &str {
+        &self.id
+    }
 
     fn list_collections(&self) -> Result<Vec<CollectionId>> {
-        Ok(self.executions.read().expect("poisoned").keys().cloned().collect())
+        Ok(self
+            .executions
+            .read()
+            .expect("poisoned")
+            .keys()
+            .cloned()
+            .collect())
     }
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(PulledBatch {
             collection: collection.to_string(),
             ids: c.ids.clone(),
@@ -283,12 +309,12 @@ impl BackendAdapter for RuquStabilizerBackend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(c.generation)
     }
 }
@@ -363,10 +389,18 @@ impl RuquTensorNetworkBackend {
         let vectors = tensor_network::to_pulled_batch_form(&mps);
         let dim = vectors.first().map(|v| v.len()).unwrap_or(0);
         let ids: Vec<u64> = (0..vectors.len() as u64).collect();
-        let exec = RuquExecution { ids, vectors, dim, generation: 1 };
+        let exec = RuquExecution {
+            ids,
+            vectors,
+            dim,
+            generation: 1,
+        };
         let inputs = witness::inputs_for(circuit, "tensor_network", 0, exec.generation);
         let bundle = witness::ruqu_bundle(&inputs.as_borrowed());
-        self.executions.write().expect("poisoned").insert(name.into(), exec);
+        self.executions
+            .write()
+            .expect("poisoned")
+            .insert(name.into(), exec);
         Ok(bundle)
     }
 
@@ -388,20 +422,28 @@ impl RuquTensorNetworkBackend {
 }
 
 impl BackendAdapter for RuquTensorNetworkBackend {
-    fn id(&self) -> &str { &self.id }
+    fn id(&self) -> &str {
+        &self.id
+    }
 
     fn list_collections(&self) -> Result<Vec<CollectionId>> {
-        Ok(self.executions.read().expect("poisoned").keys().cloned().collect())
+        Ok(self
+            .executions
+            .read()
+            .expect("poisoned")
+            .keys()
+            .cloned()
+            .collect())
     }
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(PulledBatch {
             collection: collection.to_string(),
             ids: c.ids.clone(),
@@ -413,12 +455,12 @@ impl BackendAdapter for RuquTensorNetworkBackend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.executions.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(c.generation)
     }
 }

--- a/crates/ruqu-backend/src/limits.rs
+++ b/crates/ruqu-backend/src/limits.rs
@@ -95,16 +95,26 @@ mod tests {
     #[test]
     fn hard_ceiling_is_not_self_contradictory() {
         // The advertised v0.0 cap must be at or below the hard ceiling.
-        assert!(MAX_QUBITS_V0_0 <= MAX_QUBITS_HARD);
+        const {
+            assert!(MAX_QUBITS_V0_0 <= MAX_QUBITS_HARD);
+        }
         // The hard ceiling must be strictly below the `dim()` saturation
         // point (31) so we never get within a factor of two of OOM on
         // a 32 GiB host.
-        assert!(MAX_QUBITS_HARD < 31);
+        const {
+            assert!(MAX_QUBITS_HARD < 31);
+        }
     }
 
     #[test]
     fn error_display_mentions_inputs() {
-        let s = format!("{}", QubitCapError { requested: 25, cap: 16 });
+        let s = format!(
+            "{}",
+            QubitCapError {
+                requested: 25,
+                cap: 16
+            }
+        );
         assert!(s.contains("25"));
         assert!(s.contains("16"));
     }

--- a/crates/ruqu-backend/src/qec.rs
+++ b/crates/ruqu-backend/src/qec.rs
@@ -129,9 +129,7 @@ pub fn plan_surface_code(
     };
 
     // Total physical qubits needed for this logical circuit.
-    let total = footprint_per_logical
-        .checked_mul(logical.n_qubits.max(1) as usize)
-        .unwrap_or(usize::MAX);
+    let total = footprint_per_logical.saturating_mul(logical.n_qubits.max(1) as usize);
 
     if total > max_physical_qubits {
         return Err(QecError::DistanceTooLargeForFootprint {
@@ -181,8 +179,14 @@ fn build_encoding(logical: &Circuit, distance: u8, physical_qubits: usize) -> Ci
             for i in 0..n_logical {
                 let base = (3 * i) as u8;
                 if (base as usize) + 2 < physical_qubits {
-                    c.push(Gate::Cx { control: base, target: base + 1 });
-                    c.push(Gate::Cx { control: base, target: base + 2 });
+                    c.push(Gate::Cx {
+                        control: base,
+                        target: base + 1,
+                    });
+                    c.push(Gate::Cx {
+                        control: base,
+                        target: base + 2,
+                    });
                 }
             }
         }
@@ -212,7 +216,10 @@ fn build_encoding(logical: &Circuit, distance: u8, physical_qubits: usize) -> Ci
                         && (data as usize) < physical_qubits
                         && ancilla != data
                     {
-                        c.push(Gate::Cx { control: ancilla, target: data });
+                        c.push(Gate::Cx {
+                            control: ancilla,
+                            target: data,
+                        });
                     }
                 }
             }
@@ -237,8 +244,14 @@ fn build_syndrome_round(logical: &Circuit, distance: u8, physical_qubits: usize)
                     // Compare data[base] vs data[base+1] via a CX
                     // chain into a virtual ancilla — for v0.2 we re-
                     // use data[base+2] as the parity register.
-                    c.push(Gate::Cx { control: base, target: base + 2 });
-                    c.push(Gate::Cx { control: base + 1, target: base + 2 });
+                    c.push(Gate::Cx {
+                        control: base,
+                        target: base + 2,
+                    });
+                    c.push(Gate::Cx {
+                        control: base + 1,
+                        target: base + 2,
+                    });
                 }
             }
         }
@@ -255,7 +268,10 @@ fn build_syndrome_round(logical: &Circuit, distance: u8, physical_qubits: usize)
                         && (data as usize) < physical_qubits
                         && ancilla != data
                     {
-                        c.push(Gate::Cx { control: data, target: ancilla });
+                        c.push(Gate::Cx {
+                            control: data,
+                            target: ancilla,
+                        });
                     }
                 }
                 for j in 0..half {

--- a/crates/ruqu-backend/src/stabilizer.rs
+++ b/crates/ruqu-backend/src/stabilizer.rs
@@ -137,17 +137,25 @@ impl Tableau {
     }
 
     /// `n_qubits` the tableau is sized for.
-    pub fn n_qubits(&self) -> usize { self.n }
+    pub fn n_qubits(&self) -> usize {
+        self.n
+    }
 
     /// Words per row — useful for callers serialising the raw storage.
-    pub fn words_per_row(&self) -> usize { self.words_per_row }
+    pub fn words_per_row(&self) -> usize {
+        self.words_per_row
+    }
 
     /// Total number of rows (`2n + 1`).
-    pub fn rows(&self) -> usize { 2 * self.n + 1 }
+    pub fn rows(&self) -> usize {
+        2 * self.n + 1
+    }
 
     /// Borrow the raw packed storage. Layout is documented on
     /// [`Tableau`].
-    pub fn raw(&self) -> &[u64] { &self.data }
+    pub fn raw(&self) -> &[u64] {
+        &self.data
+    }
 
     /// Read the bit at `(row, col)`. `col ∈ 0..n` reads `x_col`,
     /// `col ∈ n..2n` reads `z_{col - n}`, `col == 2n` reads the sign
@@ -174,20 +182,32 @@ impl Tableau {
     /// hot paths to warrant a dedicated helper.
     #[inline]
     pub fn xor_bit(&mut self, row: usize, col: usize, v: bool) {
-        if !v { return; }
+        if !v {
+            return;
+        }
         let (w, b) = self.bit_pos(row, col);
         self.data[w] ^= 1u64 << b;
     }
 
     /// Read the `x_{row, q}` bit. Convenience for the gate updates.
-    #[inline] pub fn x(&self, row: usize, q: usize) -> bool { self.bit(row, q) }
+    #[inline]
+    pub fn x(&self, row: usize, q: usize) -> bool {
+        self.bit(row, q)
+    }
     /// Read the `z_{row, q}` bit. Convenience for the gate updates.
-    #[inline] pub fn z(&self, row: usize, q: usize) -> bool { self.bit(row, self.n + q) }
+    #[inline]
+    pub fn z(&self, row: usize, q: usize) -> bool {
+        self.bit(row, self.n + q)
+    }
     /// Read the sign bit `r_row`. Convenience for the gate updates.
-    #[inline] pub fn r(&self, row: usize) -> bool { self.bit(row, 2 * self.n) }
+    #[inline]
+    pub fn r(&self, row: usize) -> bool {
+        self.bit(row, 2 * self.n)
+    }
 
     /// Write the sign bit `r_row`.
-    #[inline] pub fn set_r(&mut self, row: usize, v: bool) {
+    #[inline]
+    pub fn set_r(&mut self, row: usize, v: bool) {
         self.set_bit(row, 2 * self.n, v);
     }
 
@@ -213,7 +233,10 @@ pub struct StabilizerState {
 impl StabilizerState {
     /// `|0…0⟩` on `n` qubits.
     pub fn zero(n: u8) -> Self {
-        Self { n_qubits: n, tableau: Tableau::identity(n as usize) }
+        Self {
+            n_qubits: n,
+            tableau: Tableau::identity(n as usize),
+        }
     }
 }
 
@@ -226,7 +249,9 @@ pub fn apply_h(state: &mut StabilizerState, q: usize) {
     for i in 0..t.rows() {
         let xi = t.x(i, q);
         let zi = t.z(i, q);
-        if xi & zi { t.xor_bit(i, 2 * t.n, true); }
+        if xi & zi {
+            t.xor_bit(i, 2 * t.n, true);
+        }
         // swap x_{i,q} ↔ z_{i,q}
         t.set_bit(i, q, zi);
         t.set_bit(i, t.n + q, xi);
@@ -240,8 +265,12 @@ pub fn apply_s(state: &mut StabilizerState, q: usize) {
     for i in 0..t.rows() {
         let xi = t.x(i, q);
         let zi = t.z(i, q);
-        if xi & zi { t.xor_bit(i, 2 * t.n, true); }
-        if xi { t.xor_bit(i, t.n + q, true); }
+        if xi & zi {
+            t.xor_bit(i, 2 * t.n, true);
+        }
+        if xi {
+            t.xor_bit(i, t.n + q, true);
+        }
     }
 }
 
@@ -259,8 +288,12 @@ pub fn apply_cx(state: &mut StabilizerState, control: usize, target: usize) {
         if xc & zt & (xt ^ zc ^ true) {
             t.xor_bit(i, 2 * t.n, true);
         }
-        if xc { t.xor_bit(i, target, true); }
-        if zt { t.xor_bit(i, t.n + control, true); }
+        if xc {
+            t.xor_bit(i, target, true);
+        }
+        if zt {
+            t.xor_bit(i, t.n + control, true);
+        }
     }
 }
 
@@ -269,7 +302,9 @@ pub fn apply_cx(state: &mut StabilizerState, control: usize, target: usize) {
 pub fn apply_x(state: &mut StabilizerState, q: usize) {
     let t = &mut state.tableau;
     for i in 0..t.rows() {
-        if t.z(i, q) { t.xor_bit(i, 2 * t.n, true); }
+        if t.z(i, q) {
+            t.xor_bit(i, 2 * t.n, true);
+        }
     }
 }
 
@@ -277,7 +312,9 @@ pub fn apply_x(state: &mut StabilizerState, q: usize) {
 pub fn apply_z(state: &mut StabilizerState, q: usize) {
     let t = &mut state.tableau;
     for i in 0..t.rows() {
-        if t.x(i, q) { t.xor_bit(i, 2 * t.n, true); }
+        if t.x(i, q) {
+            t.xor_bit(i, 2 * t.n, true);
+        }
     }
 }
 
@@ -286,7 +323,9 @@ pub fn apply_z(state: &mut StabilizerState, q: usize) {
 pub fn apply_y(state: &mut StabilizerState, q: usize) {
     let t = &mut state.tableau;
     for i in 0..t.rows() {
-        if t.x(i, q) ^ t.z(i, q) { t.xor_bit(i, 2 * t.n, true); }
+        if t.x(i, q) ^ t.z(i, q) {
+            t.xor_bit(i, 2 * t.n, true);
+        }
     }
 }
 
@@ -305,7 +344,10 @@ pub fn simulate(circuit: &Circuit) -> Result<StabilizerState, StabilizerError> {
 
     let in_range = |q: u8| -> Result<usize, StabilizerError> {
         if q >= n {
-            Err(StabilizerError::QubitIndexOutOfRange { qubit: q, n_qubits: n })
+            Err(StabilizerError::QubitIndexOutOfRange {
+                qubit: q,
+                n_qubits: n,
+            })
         } else {
             Ok(q as usize)
         }
@@ -323,13 +365,14 @@ pub fn simulate(circuit: &Circuit) -> Result<StabilizerState, StabilizerError> {
                 let t = in_range(target)?;
                 if c == t {
                     return Err(StabilizerError::QubitIndexOutOfRange {
-                        qubit: control, n_qubits: n,
+                        qubit: control,
+                        n_qubits: n,
                     });
                 }
                 apply_cx(&mut state, c, t);
             }
-            Gate::T { .. }       => return Err(StabilizerError::NonClifford { gate: "t" }),
-            Gate::Rz { .. }      => return Err(StabilizerError::NonClifford { gate: "rz" }),
+            Gate::T { .. } => return Err(StabilizerError::NonClifford { gate: "t" }),
+            Gate::Rz { .. } => return Err(StabilizerError::NonClifford { gate: "rz" }),
         }
     }
     Ok(state)
@@ -355,9 +398,13 @@ pub fn to_pulled_batch_form(state: &StabilizerState) -> Vec<Vec<f32>> {
         let mut v = Vec::with_capacity(row_len);
         v.push(1.0_f32);
         v.push(0.0_f32);
-        for q in 0..n { v.push(if state.tableau.x(row, q) { 1.0 } else { 0.0 }); }
-        for q in 0..n { v.push(if state.tableau.z(row, q) { 1.0 } else { 0.0 }); }
-        v.push(if state.tableau.r(row)   { 1.0 } else { 0.0 });
+        for q in 0..n {
+            v.push(if state.tableau.x(row, q) { 1.0 } else { 0.0 });
+        }
+        for q in 0..n {
+            v.push(if state.tableau.z(row, q) { 1.0 } else { 0.0 });
+        }
+        v.push(if state.tableau.r(row) { 1.0 } else { 0.0 });
         out.push(v);
     }
     out
@@ -374,15 +421,27 @@ mod tests {
         // Destabilizer i should have x_{i,i} = 1, all other bits 0.
         for i in 0..3 {
             assert!(t.x(i, i));
-            for j in 0..3 { if j != i { assert!(!t.x(i, j)); } }
-            for j in 0..3 { assert!(!t.z(i, j)); }
+            for j in 0..3 {
+                if j != i {
+                    assert!(!t.x(i, j));
+                }
+            }
+            for j in 0..3 {
+                assert!(!t.z(i, j));
+            }
             assert!(!t.r(i));
         }
         // Stabilizer i should have z_{i,i} = 1.
         for i in 0..3 {
             assert!(t.z(3 + i, i));
-            for j in 0..3 { if j != i { assert!(!t.z(3 + i, j)); } }
-            for j in 0..3 { assert!(!t.x(3 + i, j)); }
+            for j in 0..3 {
+                if j != i {
+                    assert!(!t.z(3 + i, j));
+                }
+            }
+            for j in 0..3 {
+                assert!(!t.x(3 + i, j));
+            }
             assert!(!t.r(3 + i));
         }
     }
@@ -442,8 +501,11 @@ mod tests {
     #[test]
     fn simulate_bell_runs_clean() {
         let mut c = Circuit::new("bell-stab", 2);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let s = simulate(&c).unwrap();
         // After H on q0 then CX(0,1) starting from Z_0, Z_1:
         // stabilizers should be X_0 X_1 and Z_0 Z_1.

--- a/crates/ruqu-backend/src/state_vector.rs
+++ b/crates/ruqu-backend/src/state_vector.rs
@@ -19,27 +19,55 @@ pub struct C {
 
 impl C {
     /// Build from a `(real, imag)` pair.
-    pub const fn new(re: f64, im: f64) -> Self { Self { re, im } }
+    pub const fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
     /// `0 + 0i`.
-    pub const fn zero() -> Self { Self { re: 0.0, im: 0.0 } }
+    pub const fn zero() -> Self {
+        Self { re: 0.0, im: 0.0 }
+    }
     /// `1 + 0i`.
-    pub const fn one() -> Self { Self { re: 1.0, im: 0.0 } }
-    /// Componentwise add.
-    pub fn add(self, o: Self) -> Self { Self { re: self.re + o.re, im: self.im + o.im } }
-    /// Componentwise subtract.
-    pub fn sub(self, o: Self) -> Self { Self { re: self.re - o.re, im: self.im - o.im } }
+    pub const fn one() -> Self {
+        Self { re: 1.0, im: 0.0 }
+    }
+    /// `|z|² = re² + im²`.
+    pub fn norm_sq(self) -> f64 {
+        self.re * self.re + self.im * self.im
+    }
+}
+
+impl std::ops::Add for C {
+    type Output = Self;
+    fn add(self, o: Self) -> Self {
+        Self {
+            re: self.re + o.re,
+            im: self.im + o.im,
+        }
+    }
+}
+
+impl std::ops::Sub for C {
+    type Output = Self;
+    fn sub(self, o: Self) -> Self {
+        Self {
+            re: self.re - o.re,
+            im: self.im - o.im,
+        }
+    }
+}
+
+impl std::ops::Mul for C {
+    type Output = Self;
     /// Complex multiply: `(a+bi)(c+di) = (ac-bd) + (ad+bc)i`.
-    pub fn mul(self, o: Self) -> Self {
+    fn mul(self, o: Self) -> Self {
         Self {
             re: self.re * o.re - self.im * o.im,
             im: self.re * o.im + self.im * o.re,
         }
     }
-    /// `|z|² = re² + im²`.
-    pub fn norm_sq(self) -> f64 { self.re * self.re + self.im * self.im }
 }
 
-const FRAC_1_SQRT_2: f64 = 0.7071067811865476;
+use std::f64::consts::FRAC_1_SQRT_2;
 
 /// Run a circuit from |0…0⟩. Returns the full state vector of length
 /// `1 << n_qubits`.
@@ -50,41 +78,42 @@ pub fn simulate(c: &Circuit) -> Vec<C> {
 
     for g in &c.gates {
         match *g {
-            Gate::H  { q } => apply_1q(&mut sv, q, [
-                [C::new(FRAC_1_SQRT_2, 0.0), C::new( FRAC_1_SQRT_2, 0.0)],
-                [C::new(FRAC_1_SQRT_2, 0.0), C::new(-FRAC_1_SQRT_2, 0.0)],
-            ]),
-            Gate::X  { q } => apply_1q(&mut sv, q, [
-                [C::zero(), C::one()],
-                [C::one(),  C::zero()],
-            ]),
-            Gate::Y  { q } => apply_1q(&mut sv, q, [
-                [C::zero(),         C::new(0.0, -1.0)],
-                [C::new(0.0, 1.0),  C::zero()],
-            ]),
-            Gate::Z  { q } => apply_1q(&mut sv, q, [
-                [C::one(),  C::zero()],
-                [C::zero(), C::new(-1.0, 0.0)],
-            ]),
-            Gate::S  { q } => apply_1q(&mut sv, q, [
-                [C::one(),  C::zero()],
-                [C::zero(), C::new(0.0, 1.0)],
-            ]),
-            Gate::T  { q } => {
+            Gate::H { q } => apply_1q(
+                &mut sv,
+                q,
+                [
+                    [C::new(FRAC_1_SQRT_2, 0.0), C::new(FRAC_1_SQRT_2, 0.0)],
+                    [C::new(FRAC_1_SQRT_2, 0.0), C::new(-FRAC_1_SQRT_2, 0.0)],
+                ],
+            ),
+            Gate::X { q } => apply_1q(&mut sv, q, [[C::zero(), C::one()], [C::one(), C::zero()]]),
+            Gate::Y { q } => apply_1q(
+                &mut sv,
+                q,
+                [
+                    [C::zero(), C::new(0.0, -1.0)],
+                    [C::new(0.0, 1.0), C::zero()],
+                ],
+            ),
+            Gate::Z { q } => apply_1q(
+                &mut sv,
+                q,
+                [[C::one(), C::zero()], [C::zero(), C::new(-1.0, 0.0)]],
+            ),
+            Gate::S { q } => apply_1q(
+                &mut sv,
+                q,
+                [[C::one(), C::zero()], [C::zero(), C::new(0.0, 1.0)]],
+            ),
+            Gate::T { q } => {
                 let phase = C::new(FRAC_1_SQRT_2, FRAC_1_SQRT_2); // e^{iπ/4}
-                apply_1q(&mut sv, q, [
-                    [C::one(),  C::zero()],
-                    [C::zero(), phase],
-                ]);
+                apply_1q(&mut sv, q, [[C::one(), C::zero()], [C::zero(), phase]]);
             }
             Gate::Rz { q, theta } => {
                 let half = theta / 2.0;
                 let neg = C::new(half.cos(), -half.sin());
-                let pos = C::new(half.cos(),  half.sin());
-                apply_1q(&mut sv, q, [
-                    [neg,       C::zero()],
-                    [C::zero(), pos],
-                ]);
+                let pos = C::new(half.cos(), half.sin());
+                apply_1q(&mut sv, q, [[neg, C::zero()], [C::zero(), pos]]);
             }
             Gate::Cx { control, target } => apply_cx(&mut sv, control, target),
         }
@@ -100,8 +129,8 @@ fn apply_1q(sv: &mut [C], q: u8, m: [[C; 2]; 2]) {
             let j = i | bit;
             let a = sv[i];
             let b = sv[j];
-            sv[i] = m[0][0].mul(a).add(m[0][1].mul(b));
-            sv[j] = m[1][0].mul(a).add(m[1][1].mul(b));
+            sv[i] = m[0][0] * a + m[0][1] * b;
+            sv[j] = m[1][0] * a + m[1][1] * b;
         }
         i += 1;
     }
@@ -109,7 +138,7 @@ fn apply_1q(sv: &mut [C], q: u8, m: [[C; 2]; 2]) {
 
 fn apply_cx(sv: &mut [C], control: u8, target: u8) {
     let cb = 1usize << (control as usize);
-    let tb = 1usize << (target  as usize);
+    let tb = 1usize << (target as usize);
     let mut i = 0;
     while i < sv.len() {
         if (i & cb) != 0 && (i & tb) == 0 {
@@ -146,13 +175,16 @@ mod tests {
     #[test]
     fn bell_pair_h_then_cx() {
         let mut c = Circuit::new("bell", 2);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let sv = simulate(&c);
         let amp = FRAC_1_SQRT_2;
         assert!((sv[0b00].re - amp).abs() < 1e-12, "|00⟩ amplitude");
-        assert!( sv[0b01].re.abs() < 1e-12, "|01⟩ should be zero");
-        assert!( sv[0b10].re.abs() < 1e-12, "|10⟩ should be zero");
+        assert!(sv[0b01].re.abs() < 1e-12, "|01⟩ should be zero");
+        assert!(sv[0b10].re.abs() < 1e-12, "|10⟩ should be zero");
         assert!((sv[0b11].re - amp).abs() < 1e-12, "|11⟩ amplitude");
         assert!((norm_sq_total(&sv) - 1.0).abs() < 1e-12);
     }

--- a/crates/ruqu-backend/src/tensor_network.rs
+++ b/crates/ruqu-backend/src/tensor_network.rs
@@ -76,7 +76,7 @@ pub const MAX_QUBITS_TN: u8 = 128;
 /// shallow depth, etc.) without breaking the bank on 64-qubit states.
 pub const DEFAULT_BOND_DIM: usize = 16;
 
-const FRAC_1_SQRT_2: f64 = 0.7071067811865476;
+use std::f64::consts::FRAC_1_SQRT_2;
 
 /// One MPS site tensor — rank 3 with axes
 /// `[bond_left, physical (=2), bond_right]`.
@@ -189,8 +189,8 @@ impl Mps {
             for r in 0..cr {
                 let v0 = t[[l, 0, r]];
                 let v1 = t[[l, 1, r]];
-                out[[l, 0, r]] = gate[0][0].mul(v0).add(gate[0][1].mul(v1));
-                out[[l, 1, r]] = gate[1][0].mul(v0).add(gate[1][1].mul(v1));
+                out[[l, 0, r]] = gate[0][0] * v0 + gate[0][1] * v1;
+                out[[l, 1, r]] = gate[1][0] * v0 + gate[1][1] * v1;
             }
         }
         *t = out;
@@ -221,7 +221,7 @@ impl Mps {
                     for s2 in 0..2 {
                         let mut acc = C::zero();
                         for m in 0..cm {
-                            acc = acc.add(left[[l, s1, m]].mul(right[[m, s2, r]]));
+                            acc = acc + left[[l, s1, m]] * right[[m, s2, r]];
                         }
                         merged[[l, s1, s2, r]] = acc;
                     }
@@ -240,9 +240,11 @@ impl Mps {
                     merged[[l, 1, 0, r]],
                     merged[[l, 1, 1, r]],
                 ];
-                for i in 0..4 {
+                for (i, gate_row) in gate.iter().enumerate() {
                     let mut acc = C::zero();
-                    for j in 0..4 { acc = acc.add(gate[i][j].mul(v[j])); }
+                    for j in 0..4 {
+                        acc = acc + gate_row[j] * v[j];
+                    }
                     let s1 = i >> 1;
                     let s2 = i & 1;
                     after[[l, s1, s2, r]] = acc;
@@ -305,7 +307,9 @@ impl Mps {
     /// two-qubit gate that can grow the bond dimension; we rely on
     /// the bond cap to keep growth bounded.
     pub fn apply_2q(&mut self, q1: u8, q2: u8, gate: [[C; 4]; 4]) -> f64 {
-        if q1 == q2 { return 0.0; }
+        if q1 == q2 {
+            return 0.0;
+        }
         let (lo, hi, swap_orientation) = if q1 < q2 {
             (q1, q2, false)
         } else {
@@ -319,7 +323,11 @@ impl Mps {
         // Now the gate's two operands sit on (lo, lo+1). If the
         // caller's q1 > q2 we have to swap operands of the gate so
         // (s1, s2) means (q1, q2) the way the caller expects.
-        let final_gate = if swap_orientation { swap_gate_axes(&gate) } else { gate };
+        let final_gate = if swap_orientation {
+            swap_gate_axes(&gate)
+        } else {
+            gate
+        };
         err_acc += self.apply_2q_adjacent(lo, final_gate);
         // SWAP everything back.
         for k in lo + 1..hi {
@@ -352,7 +360,7 @@ impl Mps {
                     for j in 0..cr {
                         let mut acc = C::zero();
                         for k in 0..cl {
-                            acc = acc.add(row[[i, k]].mul(slice[[k, j]]));
+                            acc = acc + row[[i, k]] * slice[[k, j]];
                         }
                         next[[i, j]] = acc;
                     }
@@ -383,18 +391,26 @@ pub fn simulate(circuit: &Circuit, bond_dim_cap: usize) -> Result<Mps, TensorNet
 
     let in_range = |q: u8| -> Result<u8, TensorNetworkError> {
         if q >= n {
-            Err(TensorNetworkError::QubitIndexOutOfRange { qubit: q, n_qubits: n })
-        } else { Ok(q) }
+            Err(TensorNetworkError::QubitIndexOutOfRange {
+                qubit: q,
+                n_qubits: n,
+            })
+        } else {
+            Ok(q)
+        }
     };
 
     for g in &circuit.gates {
         match *g {
             Gate::H { q } => {
                 let _ = in_range(q)?;
-                mps.apply_1q(q, [
-                    [C::new(FRAC_1_SQRT_2, 0.0), C::new( FRAC_1_SQRT_2, 0.0)],
-                    [C::new(FRAC_1_SQRT_2, 0.0), C::new(-FRAC_1_SQRT_2, 0.0)],
-                ]);
+                mps.apply_1q(
+                    q,
+                    [
+                        [C::new(FRAC_1_SQRT_2, 0.0), C::new(FRAC_1_SQRT_2, 0.0)],
+                        [C::new(FRAC_1_SQRT_2, 0.0), C::new(-FRAC_1_SQRT_2, 0.0)],
+                    ],
+                );
             }
             Gate::X { q } => {
                 let _ = in_range(q)?;
@@ -402,10 +418,13 @@ pub fn simulate(circuit: &Circuit, bond_dim_cap: usize) -> Result<Mps, TensorNet
             }
             Gate::Y { q } => {
                 let _ = in_range(q)?;
-                mps.apply_1q(q, [
-                    [C::zero(),         C::new(0.0, -1.0)],
-                    [C::new(0.0, 1.0),  C::zero()],
-                ]);
+                mps.apply_1q(
+                    q,
+                    [
+                        [C::zero(), C::new(0.0, -1.0)],
+                        [C::new(0.0, 1.0), C::zero()],
+                    ],
+                );
             }
             Gate::Z { q } => {
                 let _ = in_range(q)?;
@@ -424,7 +443,7 @@ pub fn simulate(circuit: &Circuit, bond_dim_cap: usize) -> Result<Mps, TensorNet
                 let _ = in_range(q)?;
                 let half = theta / 2.0;
                 let neg = C::new(half.cos(), -half.sin());
-                let pos = C::new(half.cos(),  half.sin());
+                let pos = C::new(half.cos(), half.sin());
                 mps.apply_1q(q, [[neg, C::zero()], [C::zero(), pos]]);
             }
             Gate::Cx { control, target } => {
@@ -449,7 +468,9 @@ pub fn simulate(circuit: &Circuit, bond_dim_cap: usize) -> Result<Mps, TensorNet
 /// ruLake's RaBitQ layer sees a uniform `dim`.
 pub fn to_pulled_batch_form(mps: &Mps) -> Vec<Vec<f32>> {
     // Determine max payload size = 2 + 2 * max(χL · 2 · χR).
-    let max_elems = mps.tensors.iter()
+    let max_elems = mps
+        .tensors
+        .iter()
         .map(|t| t.dim().0 * t.dim().1 * t.dim().2)
         .max()
         .unwrap_or(0);
@@ -464,7 +485,9 @@ pub fn to_pulled_batch_form(mps: &Mps) -> Vec<Vec<f32>> {
             row.push(c.im as f32);
         }
         // Zero-pad to row_len.
-        while row.len() < row_len { row.push(0.0); }
+        while row.len() < row_len {
+            row.push(0.0);
+        }
         out.push(row);
     }
     out
@@ -477,18 +500,15 @@ fn scale_real(c: C, s: f64) -> C {
 }
 
 /// `Cᴴ` — complex-conjugate, no transpose.
-fn cconj(c: C) -> C { C::new(c.re, -c.im) }
+fn cconj(c: C) -> C {
+    C::new(c.re, -c.im)
+}
 
 /// 4×4 SWAP gate. Standard basis order |s1 s2⟩ ∈ {|00⟩, |01⟩, |10⟩, |11⟩}.
 fn swap_gate() -> [[C; 4]; 4] {
     let z = C::zero();
     let o = C::one();
-    [
-        [o, z, z, z],
-        [z, z, o, z],
-        [z, o, z, z],
-        [z, z, z, o],
-    ]
+    [[o, z, z, z], [z, z, o, z], [z, o, z, z], [z, z, z, o]]
 }
 
 /// CNOT in the basis order |s1 s2⟩ where the first index is the
@@ -501,21 +521,11 @@ fn cnot_gate(control_is_left: bool) -> [[C; 4]; 4] {
     if control_is_left {
         // CNOT with control on s1, target on s2:
         // |00⟩→|00⟩, |01⟩→|01⟩, |10⟩→|11⟩, |11⟩→|10⟩.
-        [
-            [o, z, z, z],
-            [z, o, z, z],
-            [z, z, z, o],
-            [z, z, o, z],
-        ]
+        [[o, z, z, z], [z, o, z, z], [z, z, z, o], [z, z, o, z]]
     } else {
         // CNOT with control on s2, target on s1:
         // |00⟩→|00⟩, |01⟩→|11⟩, |10⟩→|10⟩, |11⟩→|01⟩.
-        [
-            [o, z, z, z],
-            [z, z, z, o],
-            [z, z, o, z],
-            [z, o, z, z],
-        ]
+        [[o, z, z, z], [z, z, z, o], [z, z, o, z], [z, o, z, z]]
     }
 }
 
@@ -561,7 +571,7 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
             for j in 0..n {
                 let mut acc = C::zero();
                 for r in 0..m {
-                    acc = acc.add(cconj(a[[r, i]]).mul(a[[r, j]]));
+                    acc = acc + cconj(a[[r, i]]) * a[[r, j]];
                 }
                 b[[i, j]] = acc;
             }
@@ -569,7 +579,11 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
         let (eigvals, eigvecs) = jacobi_eigen_hermitian(&b);
         // Sort eigenpairs by descending eigenvalue.
         let mut order: Vec<usize> = (0..n).collect();
-        order.sort_by(|&a, &b| eigvals[b].partial_cmp(&eigvals[a]).unwrap_or(std::cmp::Ordering::Equal));
+        order.sort_by(|&a, &b| {
+            eigvals[b]
+                .partial_cmp(&eigvals[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         let mut sigma = Vec::with_capacity(k);
         let mut v = Array2::<C>::default((n, k));
@@ -578,7 +592,9 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
             let lam = eigvals[idx].max(0.0);
             let s = lam.sqrt();
             sigma.push(s);
-            for i in 0..n { v[[i, slot]] = eigvecs[[i, idx]]; }
+            for i in 0..n {
+                v[[i, slot]] = eigvecs[[i, idx]];
+            }
             // u_slot = A v_slot / σ_slot (if σ ≈ 0, leave column as
             // zero; the corresponding singular direction has no
             // amplitude, so MPS contraction won't read it).
@@ -586,7 +602,7 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
                 for r in 0..m {
                     let mut acc = C::zero();
                     for i in 0..n {
-                        acc = acc.add(a[[r, i]].mul(v[[i, slot]]));
+                        acc = acc + a[[r, i]] * v[[i, slot]];
                     }
                     u[[r, slot]] = scale_real(acc, 1.0 / s);
                 }
@@ -594,7 +610,11 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
         }
         // Vᴴ has rows = conjugate-transpose of v's columns.
         let mut vt = Array2::<C>::default((k, n));
-        for i in 0..k { for j in 0..n { vt[[i, j]] = cconj(v[[j, i]]); } }
+        for i in 0..k {
+            for j in 0..n {
+                vt[[i, j]] = cconj(v[[j, i]]);
+            }
+        }
         (u, sigma, vt)
     } else {
         // m < n: diagonalise C = A Aᴴ (m × m). Eigenvectors give U;
@@ -604,14 +624,18 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
             for j in 0..m {
                 let mut acc = C::zero();
                 for r in 0..n {
-                    acc = acc.add(a[[i, r]].mul(cconj(a[[j, r]])));
+                    acc = acc + a[[i, r]] * cconj(a[[j, r]]);
                 }
                 c_mat[[i, j]] = acc;
             }
         }
         let (eigvals, eigvecs) = jacobi_eigen_hermitian(&c_mat);
         let mut order: Vec<usize> = (0..m).collect();
-        order.sort_by(|&a, &b| eigvals[b].partial_cmp(&eigvals[a]).unwrap_or(std::cmp::Ordering::Equal));
+        order.sort_by(|&a, &b| {
+            eigvals[b]
+                .partial_cmp(&eigvals[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
         let mut sigma = Vec::with_capacity(k);
         let mut u = Array2::<C>::default((m, k));
@@ -620,13 +644,15 @@ fn svd_complex(a: &Array2<C>) -> (Array2<C>, Vec<f64>, Array2<C>) {
             let lam = eigvals[idx].max(0.0);
             let s = lam.sqrt();
             sigma.push(s);
-            for i in 0..m { u[[i, slot]] = eigvecs[[i, idx]]; }
+            for i in 0..m {
+                u[[i, slot]] = eigvecs[[i, idx]];
+            }
             if s > 1e-14 {
                 // Row of Vᴴ at slot = (1/s) · uᴴ_slot · A.
                 for j in 0..n {
                     let mut acc = C::zero();
                     for i in 0..m {
-                        acc = acc.add(cconj(u[[i, slot]]).mul(a[[i, j]]));
+                        acc = acc + cconj(u[[i, slot]]) * a[[i, j]];
                     }
                     vt[[slot, j]] = scale_real(acc, 1.0 / s);
                 }
@@ -647,7 +673,9 @@ fn jacobi_eigen_hermitian(h: &Array2<C>) -> (Array1<f64>, Array2<C>) {
     let mut a = h.clone();
     // Initialise V = I.
     let mut v = Array2::<C>::default((n, n));
-    for i in 0..n { v[[i, i]] = C::one(); }
+    for i in 0..n {
+        v[[i, i]] = C::one();
+    }
 
     let max_sweeps = 80;
     let tol = 1e-14;
@@ -660,12 +688,16 @@ fn jacobi_eigen_hermitian(h: &Array2<C>) -> (Array1<f64>, Array2<C>) {
                 off += a[[i, j]].norm_sq();
             }
         }
-        if off < tol { break; }
+        if off < tol {
+            break;
+        }
 
         for p in 0..n {
             for q in (p + 1)..n {
                 let apq = a[[p, q]];
-                if apq.norm_sq() < 1e-30 { continue; }
+                if apq.norm_sq() < 1e-30 {
+                    continue;
+                }
                 let app = a[[p, p]].re; // diagonal of Hermitian is real.
                 let aqq = a[[q, q]].re;
                 let modulus = apq.norm_sq().sqrt();
@@ -693,13 +725,15 @@ fn jacobi_eigen_hermitian(h: &Array2<C>) -> (Array1<f64>, Array2<C>) {
 
                 // Update off-diagonal entries in rows/cols p and q.
                 for i in 0..n {
-                    if i == p || i == q { continue; }
+                    if i == p || i == q {
+                        continue;
+                    }
                     let aip = a[[i, p]];
                     let aiq = a[[i, q]];
                     // Rotation: aip' = c·aip + s·phase·aiq.
                     //           aiq' = -s·phase_conj·aip + c·aiq.
-                    let new_aip = scale_real(aip, c_t).add(scale_real(phase.mul(aiq), s_t));
-                    let new_aiq = scale_real(phase_conj.mul(aip), -s_t).add(scale_real(aiq, c_t));
+                    let new_aip = scale_real(aip, c_t) + scale_real(phase * aiq, s_t);
+                    let new_aiq = scale_real(phase_conj * aip, -s_t) + scale_real(aiq, c_t);
                     a[[i, p]] = new_aip;
                     a[[p, i]] = cconj(new_aip);
                     a[[i, q]] = new_aiq;
@@ -710,8 +744,8 @@ fn jacobi_eigen_hermitian(h: &Array2<C>) -> (Array1<f64>, Array2<C>) {
                 for i in 0..n {
                     let vip = v[[i, p]];
                     let viq = v[[i, q]];
-                    let new_vip = scale_real(vip, c_t).add(scale_real(phase.mul(viq), s_t));
-                    let new_viq = scale_real(phase_conj.mul(vip), -s_t).add(scale_real(viq, c_t));
+                    let new_vip = scale_real(vip, c_t) + scale_real(phase * viq, s_t);
+                    let new_viq = scale_real(phase_conj * vip, -s_t) + scale_real(viq, c_t);
                     v[[i, p]] = new_vip;
                     v[[i, q]] = new_viq;
                 }
@@ -720,7 +754,9 @@ fn jacobi_eigen_hermitian(h: &Array2<C>) -> (Array1<f64>, Array2<C>) {
     }
 
     let mut eigvals = Array1::<f64>::zeros(n);
-    for i in 0..n { eigvals[i] = a[[i, i]].re; }
+    for i in 0..n {
+        eigvals[i] = a[[i, i]].re;
+    }
     (eigvals, v)
 }
 
@@ -729,7 +765,9 @@ mod tests {
     use super::*;
     use crate::circuit::{Circuit, Gate};
 
-    fn approx(a: f64, b: f64, eps: f64) -> bool { (a - b).abs() < eps }
+    fn approx(a: f64, b: f64, eps: f64) -> bool {
+        (a - b).abs() < eps
+    }
 
     #[test]
     fn zero_state_has_unit_amplitude_on_basis_zero() {
@@ -738,9 +776,9 @@ mod tests {
         assert_eq!(sv.len(), 8);
         assert!(approx(sv[0].re, 1.0, 1e-12));
         assert!(approx(sv[0].im, 0.0, 1e-12));
-        for i in 1..8 {
-            assert!(approx(sv[i].re, 0.0, 1e-12));
-            assert!(approx(sv[i].im, 0.0, 1e-12));
+        for elem in sv.iter().take(8).skip(1) {
+            assert!(approx(elem.re, 0.0, 1e-12));
+            assert!(approx(elem.im, 0.0, 1e-12));
         }
     }
 
@@ -758,16 +796,30 @@ mod tests {
     #[test]
     fn bell_pair_at_bond_dim_two() {
         let mut c = Circuit::new("bell-mps", 2);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let mps = simulate(&c, 2).unwrap();
         let sv = mps.to_state_vector();
         let amp = FRAC_1_SQRT_2;
-        assert!(approx(sv[0b00].re, amp, 1e-10), "|00⟩ amp = {}", sv[0b00].re);
+        assert!(
+            approx(sv[0b00].re, amp, 1e-10),
+            "|00⟩ amp = {}",
+            sv[0b00].re
+        );
         assert!(approx(sv[0b01].re, 0.0, 1e-10), "|01⟩ should be zero");
         assert!(approx(sv[0b10].re, 0.0, 1e-10), "|10⟩ should be zero");
-        assert!(approx(sv[0b11].re, amp, 1e-10), "|11⟩ amp = {}", sv[0b11].re);
-        assert!(mps.truncation_error < 1e-12, "Bell pair fits exactly at χ=2");
+        assert!(
+            approx(sv[0b11].re, amp, 1e-10),
+            "|11⟩ amp = {}",
+            sv[0b11].re
+        );
+        assert!(
+            mps.truncation_error < 1e-12,
+            "Bell pair fits exactly at χ=2"
+        );
     }
 
     #[test]
@@ -793,16 +845,19 @@ mod tests {
     fn nonadjacent_cnot_via_swap_decomp() {
         // CNOT(0, 2) on |+00⟩ should give (|000⟩ + |101⟩)/√2.
         let mut c = Circuit::new("non-adj-cnot", 3);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 2 });
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 2,
+        });
         let mps = simulate(&c, 4).unwrap();
         let sv = mps.to_state_vector();
         let amp = FRAC_1_SQRT_2;
         assert!(approx(sv[0b000].re, amp, 1e-10), "|000⟩ amp");
         assert!(approx(sv[0b101].re, amp, 1e-10), "|101⟩ amp");
-        for i in 0..8 {
+        for (i, elem) in sv.iter().enumerate().take(8) {
             if i != 0b000 && i != 0b101 {
-                assert!(sv[i].norm_sq() < 1e-18, "basis {i:03b} should be zero");
+                assert!(elem.norm_sq() < 1e-18, "basis {i:03b} should be zero");
             }
         }
     }
@@ -810,13 +865,19 @@ mod tests {
     #[test]
     fn rejects_zero_bond_dim() {
         let c = Circuit::new("zero-bond", 1);
-        assert!(matches!(simulate(&c, 0), Err(TensorNetworkError::ZeroBondDim)));
+        assert!(matches!(
+            simulate(&c, 0),
+            Err(TensorNetworkError::ZeroBondDim)
+        ));
     }
 
     #[test]
     fn rejects_too_many_qubits() {
         let c = Circuit::new("too-wide", MAX_QUBITS_TN + 1);
-        assert!(matches!(simulate(&c, 4), Err(TensorNetworkError::TooManyQubits { .. })));
+        assert!(matches!(
+            simulate(&c, 4),
+            Err(TensorNetworkError::TooManyQubits { .. })
+        ));
     }
 
     #[test]
@@ -826,7 +887,9 @@ mod tests {
         assert_eq!(v.len(), 4);
         // All rows same width (zero-padded).
         let w = v[0].len();
-        for row in &v { assert_eq!(row.len(), w); }
+        for row in &v {
+            assert_eq!(row.len(), w);
+        }
         // First two entries are χL, χR; for |0…0⟩ both are 1.
         for row in &v {
             assert_eq!(row[0], 1.0);
@@ -838,12 +901,12 @@ mod tests {
     fn svd_round_trips_small_complex_matrix() {
         // 3×2 matrix; check A ≈ U Σ Vᴴ.
         let mut a = Array2::<C>::default((3, 2));
-        a[[0, 0]] = C::new(1.0,  0.5);
+        a[[0, 0]] = C::new(1.0, 0.5);
         a[[0, 1]] = C::new(0.0, -1.0);
-        a[[1, 0]] = C::new(2.0,  0.0);
-        a[[1, 1]] = C::new(1.0,  1.0);
+        a[[1, 0]] = C::new(2.0, 0.0);
+        a[[1, 1]] = C::new(1.0, 1.0);
         a[[2, 0]] = C::new(0.5, -0.5);
-        a[[2, 1]] = C::new(1.5,  0.0);
+        a[[2, 1]] = C::new(1.5, 0.0);
         let (u, sigma, vt) = svd_complex(&a);
         // Reconstruct.
         let mut recon = Array2::<C>::default((3, 2));
@@ -852,7 +915,7 @@ mod tests {
                 let mut acc = C::zero();
                 for k in 0..sigma.len() {
                     let s = C::new(sigma[k], 0.0);
-                    acc = acc.add(u[[i, k]].mul(s).mul(vt[[k, j]]));
+                    acc = acc + u[[i, k]] * s * vt[[k, j]];
                 }
                 recon[[i, j]] = acc;
             }
@@ -860,9 +923,11 @@ mod tests {
         for i in 0..3 {
             for j in 0..2 {
                 assert!(
-                    (a[[i, j]].re - recon[[i, j]].re).abs() < 1e-8 &&
-                    (a[[i, j]].im - recon[[i, j]].im).abs() < 1e-8,
-                    "SVD mismatch at ({i}, {j}): {:?} vs {:?}", a[[i, j]], recon[[i, j]],
+                    (a[[i, j]].re - recon[[i, j]].re).abs() < 1e-8
+                        && (a[[i, j]].im - recon[[i, j]].im).abs() < 1e-8,
+                    "SVD mismatch at ({i}, {j}): {:?} vs {:?}",
+                    a[[i, j]],
+                    recon[[i, j]],
                 );
             }
         }

--- a/crates/ruqu-backend/src/witness.rs
+++ b/crates/ruqu-backend/src/witness.rs
@@ -54,7 +54,12 @@ pub fn ruqu_bundle(inputs: &RuquWitnessInputs<'_>) -> RuLakeBundle {
 /// seed. The backend tag flows into `data_ref` so StateVector and
 /// Stabilizer over the same circuit get distinct witnesses. v0.0
 /// uses backend tag "sv" for StateVector.
-pub fn inputs_for(c: &Circuit, backend_tag: &str, seed: u64, generation: u64) -> RuquWitnessInputsOwned {
+pub fn inputs_for(
+    c: &Circuit,
+    backend_tag: &str,
+    seed: u64,
+    generation: u64,
+) -> RuquWitnessInputsOwned {
     RuquWitnessInputsOwned {
         data_ref: format!("ruqu://{}@{}", c.id, backend_tag),
         dim: c.dim(),
@@ -101,8 +106,11 @@ mod tests {
     #[test]
     fn witness_deterministic_for_same_circuit_and_seed() {
         let mut c = Circuit::new("bell", 2);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
         let i = inputs_for(&c, "sv", 0, 1);
         let a = ruqu_bundle(&i.as_borrowed());
         let b = ruqu_bundle(&i.as_borrowed());
@@ -113,9 +121,12 @@ mod tests {
     #[test]
     fn witness_changes_when_backend_tag_changes() {
         let mut c = Circuit::new("bell", 2);
-        c.push(Gate::H  { q: 0 });
-        c.push(Gate::Cx { control: 0, target: 1 });
-        let a = ruqu_bundle(&inputs_for(&c, "sv",         0, 1).as_borrowed());
+        c.push(Gate::H { q: 0 });
+        c.push(Gate::Cx {
+            control: 0,
+            target: 1,
+        });
+        let a = ruqu_bundle(&inputs_for(&c, "sv", 0, 1).as_borrowed());
         let b = ruqu_bundle(&inputs_for(&c, "stabilizer", 0, 1).as_borrowed());
         assert_ne!(
             a.rvf_witness, b.rvf_witness,

--- a/crates/ruqu-backend/tests/hardware_smoke.rs
+++ b/crates/ruqu-backend/tests/hardware_smoke.rs
@@ -11,18 +11,25 @@ use ruvector_rulake_ruqu::{Circuit, Gate, RuquHardwareStubBackend, RuquStateVect
 fn bell_circuit() -> Circuit {
     let mut c = Circuit::new("bell-hw", 2);
     c.push(Gate::H { q: 0 });
-    c.push(Gate::Cx { control: 0, target: 1 });
+    c.push(Gate::Cx {
+        control: 0,
+        target: 1,
+    });
     c
 }
 
 #[test]
 fn hardware_stub_runs_bell_pair() {
     let be = RuquHardwareStubBackend::new("ruqu-hw-fixture", 0.02, 1);
-    let bundle = be.execute("bell-pair", &bell_circuit())
+    let bundle = be
+        .execute("bell-pair", &bell_circuit())
         .expect("Hardware stub execute should succeed for Bell pair");
 
     assert_eq!(be.id(), "ruqu-hw-fixture");
-    assert_eq!(be.list_collections().unwrap(), vec!["bell-pair".to_string()]);
+    assert_eq!(
+        be.list_collections().unwrap(),
+        vec!["bell-pair".to_string()]
+    );
     assert_eq!(bundle.memory_class.as_deref(), Some("quantum"));
 
     let batch = be.pull_vectors("bell-pair").unwrap();
@@ -78,13 +85,20 @@ fn hardware_stub_round_trips_through_rulake_cache() {
     lake.register_backend(be).unwrap();
 
     let q = vec![1.0_f32, 0.0]; // dim=2 query
-    let hits1 = lake.search_one("ruqu-hw-fixture", "bell-pair", &q, 3).unwrap();
+    let hits1 = lake
+        .search_one("ruqu-hw-fixture", "bell-pair", &q, 3)
+        .unwrap();
     assert_eq!(hits1.len(), 3);
 
     // Cache hit on the second call.
-    let hits2 = lake.search_one("ruqu-hw-fixture", "bell-pair", &q, 3).unwrap();
+    let hits2 = lake
+        .search_one("ruqu-hw-fixture", "bell-pair", &q, 3)
+        .unwrap();
     assert_eq!(hits1, hits2);
 
     let stats = lake.cache_stats();
-    assert_eq!(stats.primes, 1, "second call must hit the cache, not re-prime");
+    assert_eq!(
+        stats.primes, 1,
+        "second call must hit the cache, not re-prime"
+    );
 }

--- a/crates/ruqu-backend/tests/qec_smoke.rs
+++ b/crates/ruqu-backend/tests/qec_smoke.rs
@@ -14,8 +14,7 @@ fn one_qubit_logical() -> Circuit {
 #[test]
 fn repetition_code_at_distance_3_returns_3_qubit_plan() {
     let logical = one_qubit_logical();
-    let plan = plan_surface_code(&logical, 3, 64)
-        .expect("d=3 with cap=64 must succeed");
+    let plan = plan_surface_code(&logical, 3, 64).expect("d=3 with cap=64 must succeed");
 
     assert_eq!(plan.code_distance, 3);
     assert_eq!(

--- a/crates/ruqu-backend/tests/smoke.rs
+++ b/crates/ruqu-backend/tests/smoke.rs
@@ -12,7 +12,10 @@ use ruvector_rulake_ruqu::{Circuit, Gate, RuquStateVectorBackend};
 fn bell_circuit() -> Circuit {
     let mut c = Circuit::new("bell", 2);
     c.push(Gate::H { q: 0 });
-    c.push(Gate::Cx { control: 0, target: 1 });
+    c.push(Gate::Cx {
+        control: 0,
+        target: 1,
+    });
     c
 }
 
@@ -22,7 +25,10 @@ fn statevector_backend_adapter_contract_holds() {
     let bundle = be.execute("bell-pair", &bell_circuit()).unwrap();
 
     assert_eq!(be.id(), "ruqu-fixture");
-    assert_eq!(be.list_collections().unwrap(), vec!["bell-pair".to_string()]);
+    assert_eq!(
+        be.list_collections().unwrap(),
+        vec!["bell-pair".to_string()]
+    );
     assert_eq!(bundle.memory_class.as_deref(), Some("quantum"));
 
     let batch = be.pull_vectors("bell-pair").unwrap();
@@ -87,5 +93,8 @@ fn generation_bump_invalidates_cache() {
 
     let _ = lake.search_one("ruqu-fixture", "bell-pair", &q, 3).unwrap();
     let primes_after = lake.cache_stats().primes;
-    assert!(primes_after > primes_before, "Fresh + gen bump must invalidate");
+    assert!(
+        primes_after > primes_before,
+        "Fresh + gen bump must invalidate"
+    );
 }

--- a/crates/ruqu-backend/tests/stabilizer_smoke.rs
+++ b/crates/ruqu-backend/tests/stabilizer_smoke.rs
@@ -11,18 +11,25 @@ use ruvector_rulake_ruqu::{Circuit, Gate, RuquStabilizerBackend, RuquStateVector
 fn bell_circuit() -> Circuit {
     let mut c = Circuit::new("bell-stab", 2);
     c.push(Gate::H { q: 0 });
-    c.push(Gate::Cx { control: 0, target: 1 });
+    c.push(Gate::Cx {
+        control: 0,
+        target: 1,
+    });
     c
 }
 
 #[test]
 fn bell_pair_through_stabilizer() {
     let be = RuquStabilizerBackend::new("ruqu-stab-fixture");
-    let bundle = be.execute("bell-pair", &bell_circuit())
+    let bundle = be
+        .execute("bell-pair", &bell_circuit())
         .expect("Stabilizer execute should succeed for an all-Clifford circuit");
 
     assert_eq!(be.id(), "ruqu-stab-fixture");
-    assert_eq!(be.list_collections().unwrap(), vec!["bell-pair".to_string()]);
+    assert_eq!(
+        be.list_collections().unwrap(),
+        vec!["bell-pair".to_string()]
+    );
     assert_eq!(bundle.memory_class.as_deref(), Some("quantum"));
 
     let batch = be.pull_vectors("bell-pair").unwrap();
@@ -68,15 +75,22 @@ fn stabilizer_round_trips_through_rulake_cache() {
 
     // Query in the packed-row dim (7 for n=2): [coeff_re=1, coeff_im=0, X bits, Z bits, r].
     let q = vec![1.0_f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
-    let hits1 = lake.search_one("ruqu-stab-fixture", "bell-pair", &q, 3).unwrap();
+    let hits1 = lake
+        .search_one("ruqu-stab-fixture", "bell-pair", &q, 3)
+        .unwrap();
     assert_eq!(hits1.len(), 3);
 
     // Cache hit on the second call.
-    let hits2 = lake.search_one("ruqu-stab-fixture", "bell-pair", &q, 3).unwrap();
+    let hits2 = lake
+        .search_one("ruqu-stab-fixture", "bell-pair", &q, 3)
+        .unwrap();
     assert_eq!(hits1, hits2);
 
     let stats = lake.cache_stats();
-    assert_eq!(stats.primes, 1, "second call must hit the cache, not re-prime");
+    assert_eq!(
+        stats.primes, 1,
+        "second call must hit the cache, not re-prime"
+    );
 }
 
 /// Concordance test (ADR-008 §G4): the StateVector and Stabilizer

--- a/crates/ruqu-backend/tests/tensor_network_smoke.rs
+++ b/crates/ruqu-backend/tests/tensor_network_smoke.rs
@@ -7,14 +7,15 @@ use std::sync::Arc;
 use rulake::backend::BackendAdapter;
 use rulake::cache::Consistency;
 use rulake::RuLake;
-use ruvector_rulake_ruqu::{
-    tensor_network, Circuit, Gate, RuquTensorNetworkBackend,
-};
+use ruvector_rulake_ruqu::{tensor_network, Circuit, Gate, RuquTensorNetworkBackend};
 
 fn bell_circuit() -> Circuit {
     let mut c = Circuit::new("bell-tn", 2);
     c.push(Gate::H { q: 0 });
-    c.push(Gate::Cx { control: 0, target: 1 });
+    c.push(Gate::Cx {
+        control: 0,
+        target: 1,
+    });
     c
 }
 
@@ -24,14 +25,21 @@ fn bell_pair_through_tensor_network_at_bond_2() {
     // non-trivial bond dimension. This is the load-bearing claim:
     // truncation at the cap loses zero amplitude on a state that
     // fits.
-    let mps = tensor_network::simulate(&bell_circuit(), 2)
-        .expect("MPS sim must succeed");
+    let mps = tensor_network::simulate(&bell_circuit(), 2).expect("MPS sim must succeed");
     let sv = mps.to_state_vector();
     let amp = std::f64::consts::FRAC_1_SQRT_2;
-    assert!((sv[0b00].re - amp).abs() < 1e-10, "|00⟩ amp = {}", sv[0b00].re);
+    assert!(
+        (sv[0b00].re - amp).abs() < 1e-10,
+        "|00⟩ amp = {}",
+        sv[0b00].re
+    );
     assert!(sv[0b01].re.abs() < 1e-10, "|01⟩ should be zero");
     assert!(sv[0b10].re.abs() < 1e-10, "|10⟩ should be zero");
-    assert!((sv[0b11].re - amp).abs() < 1e-10, "|11⟩ amp = {}", sv[0b11].re);
+    assert!(
+        (sv[0b11].re - amp).abs() < 1e-10,
+        "|11⟩ amp = {}",
+        sv[0b11].re
+    );
     assert!(
         mps.truncation_error < 1e-12,
         "Bell pair must fit at χ=2 with zero truncation, got {}",
@@ -41,10 +49,14 @@ fn bell_pair_through_tensor_network_at_bond_2() {
     // Round-trip the same circuit through the backend adapter to
     // confirm the witness path is wired.
     let be = RuquTensorNetworkBackend::new("ruqu-tn-fixture", 2);
-    let bundle = be.execute("bell-pair", &bell_circuit())
+    let bundle = be
+        .execute("bell-pair", &bell_circuit())
         .expect("TensorNetwork execute should succeed for the Bell circuit");
     assert_eq!(be.id(), "ruqu-tn-fixture");
-    assert_eq!(be.list_collections().unwrap(), vec!["bell-pair".to_string()]);
+    assert_eq!(
+        be.list_collections().unwrap(),
+        vec!["bell-pair".to_string()]
+    );
     assert_eq!(bundle.memory_class.as_deref(), Some("quantum"));
 }
 
@@ -59,7 +71,8 @@ fn tensor_network_handles_t_gate_unlike_stabilizer() {
     c.push(Gate::H { q: 0 });
 
     let be = RuquTensorNetworkBackend::new("ruqu-tn-non-clifford", 4);
-    let _bundle = be.execute("h-t-h", &c)
+    let _bundle = be
+        .execute("h-t-h", &c)
         .expect("TensorNetwork must accept a T gate (Stabilizer would refuse)");
 
     // Pull the cached state and check the analytic probabilities.
@@ -88,8 +101,7 @@ fn tensor_network_round_trips_through_rulake_cache() {
     });
     let be: Arc<dyn BackendAdapter> = Arc::clone(&raw) as Arc<dyn BackendAdapter>;
 
-    let lake = RuLake::new(20, 42)
-        .with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
+    let lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
     lake.register_backend(be).unwrap();
 
     // Pull the packed batch shape so we can build a valid query
@@ -100,15 +112,22 @@ fn tensor_network_round_trips_through_rulake_cache() {
     let batch = raw.pull_vectors("bell-pair").unwrap();
     let q = vec![0.0_f32; batch.dim];
 
-    let hits1 = lake.search_one("ruqu-tn-fixture", "bell-pair", &q, 2).unwrap();
+    let hits1 = lake
+        .search_one("ruqu-tn-fixture", "bell-pair", &q, 2)
+        .unwrap();
     assert_eq!(hits1.len(), 2);
 
     // Cache hit on the second call.
-    let hits2 = lake.search_one("ruqu-tn-fixture", "bell-pair", &q, 2).unwrap();
+    let hits2 = lake
+        .search_one("ruqu-tn-fixture", "bell-pair", &q, 2)
+        .unwrap();
     assert_eq!(hits1, hits2);
 
     let stats = lake.cache_stats();
-    assert_eq!(stats.primes, 1, "second call must hit the cache, not re-prime");
+    assert_eq!(
+        stats.primes, 1,
+        "second call must hit the cache, not re-prime"
+    );
 }
 
 #[test]
@@ -124,16 +143,24 @@ fn tensor_network_truncation_error_grows_with_circuit_depth() {
     let depth = 20usize;
     let mut c = Circuit::new("clifford-depth-20", n);
     for layer in 0..depth {
-        for q in 0..n { c.push(Gate::H { q }); }
+        for q in 0..n {
+            c.push(Gate::H { q });
+        }
         // Alternate the CX sweep direction layer-by-layer so the
         // entanglement spreads in both directions.
         if layer % 2 == 0 {
             for q in 0..n.saturating_sub(1) {
-                c.push(Gate::Cx { control: q, target: q + 1 });
+                c.push(Gate::Cx {
+                    control: q,
+                    target: q + 1,
+                });
             }
         } else {
             for q in (1..n).rev() {
-                c.push(Gate::Cx { control: q, target: q - 1 });
+                c.push(Gate::Cx {
+                    control: q,
+                    target: q - 1,
+                });
             }
         }
     }
@@ -165,6 +192,7 @@ fn tensor_network_truncation_error_grows_with_circuit_depth() {
     assert!(
         mps_high.truncation_error <= mps_low.truncation_error + 1e-6,
         "wider bond ({}) should track at-or-below narrower bond ({})",
-        mps_high.truncation_error, mps_low.truncation_error,
+        mps_high.truncation_error,
+        mps_low.truncation_error,
     );
 }

--- a/crates/rvdna-backend/benches/cache_priming.rs
+++ b/crates/rvdna-backend/benches/cache_priming.rs
@@ -31,7 +31,12 @@ fn fixture_collection(seed: u64, n: usize, dim: usize) -> RvdnaCollection {
     let vectors: Vec<Vec<f32>> = (0..n)
         .map(|_| (0..dim).map(|_| next() * 2.0 - 1.0).collect())
         .collect();
-    RvdnaCollection { ids, vectors, dim, generation: 1 }
+    RvdnaCollection {
+        ids,
+        vectors,
+        dim,
+        generation: 1,
+    }
 }
 
 fn build_lake_with_collection(n: usize, dim: usize) -> RuLake {
@@ -40,8 +45,7 @@ fn build_lake_with_collection(n: usize, dim: usize) -> RuLake {
         b.put_collection("col", fixture_collection(0xc0ffee, n, dim));
         b
     });
-    let lake = RuLake::new(20, 42)
-        .with_consistency(Consistency::Eventual { ttl_ms: 60_000 });
+    let lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 60_000 });
     lake.register_backend(be).unwrap();
     lake
 }

--- a/crates/rvdna-backend/benches/pull_vectors.rs
+++ b/crates/rvdna-backend/benches/pull_vectors.rs
@@ -29,7 +29,12 @@ fn fixture_collection(seed: u64, n: usize, dim: usize) -> RvdnaCollection {
     let vectors: Vec<Vec<f32>> = (0..n)
         .map(|_| (0..dim).map(|_| next() * 2.0 - 1.0).collect())
         .collect();
-    RvdnaCollection { ids, vectors, dim, generation: 1 }
+    RvdnaCollection {
+        ids,
+        vectors,
+        dim,
+        generation: 1,
+    }
 }
 
 fn bench_pull_vectors(c: &mut Criterion) {

--- a/crates/rvdna-backend/benches/t1_pull_vectors.rs
+++ b/crates/rvdna-backend/benches/t1_pull_vectors.rs
@@ -62,7 +62,12 @@ fn bench_t1_vs_t0_pull_vectors(c: &mut Criterion) {
         let name = format!("col-{n}-{dim}");
         t0.put_collection(
             &name,
-            RvdnaCollection { ids, vectors, dim, generation: 1 },
+            RvdnaCollection {
+                ids,
+                vectors,
+                dim,
+                generation: 1,
+            },
         );
 
         let t0_id = BenchmarkId::new(format!("t0-dim{dim}"), n);

--- a/crates/rvdna-backend/src/lib.rs
+++ b/crates/rvdna-backend/src/lib.rs
@@ -86,8 +86,15 @@ impl RvdnaT0Backend {
     /// Insert / replace a hot-tier collection by name.
     ///
     /// Returns the previous collection if one existed under this name.
-    pub fn put_collection(&self, name: impl Into<String>, c: RvdnaCollection) -> Option<RvdnaCollection> {
-        self.collections.write().expect("poisoned").insert(name.into(), c)
+    pub fn put_collection(
+        &self,
+        name: impl Into<String>,
+        c: RvdnaCollection,
+    ) -> Option<RvdnaCollection> {
+        self.collections
+            .write()
+            .expect("poisoned")
+            .insert(name.into(), c)
     }
 
     /// Bump the generation of a collection — call this after rotating
@@ -113,17 +120,23 @@ impl BackendAdapter for RvdnaT0Backend {
     }
 
     fn list_collections(&self) -> Result<Vec<CollectionId>> {
-        Ok(self.collections.read().expect("poisoned").keys().cloned().collect())
+        Ok(self
+            .collections
+            .read()
+            .expect("poisoned")
+            .keys()
+            .cloned()
+            .collect())
     }
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.collections.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(PulledBatch {
             collection: collection.to_string(),
             ids: c.ids.clone(),
@@ -135,12 +148,12 @@ impl BackendAdapter for RvdnaT0Backend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.collections.read().expect("poisoned");
-        let c = g.get(collection).ok_or_else(|| {
-            rulake::error::RuLakeError::UnknownCollection {
+        let c = g
+            .get(collection)
+            .ok_or_else(|| rulake::error::RuLakeError::UnknownCollection {
                 backend: self.id.clone(),
                 collection: collection.to_string(),
-            }
-        })?;
+            })?;
         Ok(c.generation)
     }
 }

--- a/crates/rvdna-backend/src/t1.rs
+++ b/crates/rvdna-backend/src/t1.rs
@@ -129,17 +129,14 @@ impl RvdnaT1Backend {
                 "rvdna-t1: dim must be > 0".into(),
             ));
         }
-        if vectors_offset % std::mem::align_of::<f32>() != 0 {
+        if !vectors_offset.is_multiple_of(std::mem::align_of::<f32>()) {
             return Err(RuLakeError::InvalidParameter(format!(
                 "rvdna-t1: vectors_offset={vectors_offset} not f32-aligned"
             )));
         }
         let path_buf = path.as_ref().to_path_buf();
         let file = std::fs::File::open(&path_buf).map_err(|e| {
-            RuLakeError::InvalidParameter(format!(
-                "rvdna-t1: open {}: {e}",
-                path_buf.display()
-            ))
+            RuLakeError::InvalidParameter(format!("rvdna-t1: open {}: {e}", path_buf.display()))
         })?;
         // SAFETY: `memmap2::Mmap::map` is `unsafe` because the OS could
         // mutate the mapped pages out from under us if another process
@@ -151,10 +148,7 @@ impl RvdnaT1Backend {
         // this single line.
         #[allow(unsafe_code)]
         let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
-            RuLakeError::InvalidParameter(format!(
-                "rvdna-t1: mmap {}: {e}",
-                path_buf.display()
-            ))
+            RuLakeError::InvalidParameter(format!("rvdna-t1: mmap {}: {e}", path_buf.display()))
         })?;
 
         // Bounds-check the declared region against the mapped length.
@@ -167,9 +161,7 @@ impl RvdnaT1Backend {
                 ))
             })?;
         let vectors_end = vectors_offset.checked_add(vectors_bytes).ok_or_else(|| {
-            RuLakeError::InvalidParameter(
-                "rvdna-t1: vectors-region offset+size overflow".into(),
-            )
+            RuLakeError::InvalidParameter("rvdna-t1: vectors-region offset+size overflow".into())
         })?;
         if vectors_end > mmap.len() {
             return Err(RuLakeError::InvalidParameter(format!(
@@ -181,14 +173,10 @@ impl RvdnaT1Backend {
             let ids_bytes = n_vectors
                 .checked_mul(std::mem::size_of::<u64>())
                 .ok_or_else(|| {
-                    RuLakeError::InvalidParameter(
-                        "rvdna-t1: ids-region size overflow".into(),
-                    )
+                    RuLakeError::InvalidParameter("rvdna-t1: ids-region size overflow".into())
                 })?;
             let ids_end = ids_offset.checked_add(ids_bytes).ok_or_else(|| {
-                RuLakeError::InvalidParameter(
-                    "rvdna-t1: ids-region offset+size overflow".into(),
-                )
+                RuLakeError::InvalidParameter("rvdna-t1: ids-region offset+size overflow".into())
             })?;
             if ids_end > mmap.len() {
                 return Err(RuLakeError::InvalidParameter(format!(
@@ -196,7 +184,7 @@ impl RvdnaT1Backend {
                     mmap.len()
                 )));
             }
-            if ids_offset % std::mem::align_of::<u64>() != 0 {
+            if !ids_offset.is_multiple_of(std::mem::align_of::<u64>()) {
                 return Err(RuLakeError::InvalidParameter(format!(
                     "rvdna-t1: ids_offset={ids_offset} not u64-aligned"
                 )));
@@ -255,10 +243,12 @@ impl BackendAdapter for RvdnaT1Backend {
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.mappings.read().expect("poisoned");
-        let m = g.get(collection).ok_or_else(|| RuLakeError::UnknownCollection {
-            backend: self.id.clone(),
-            collection: collection.to_string(),
-        })?;
+        let m = g
+            .get(collection)
+            .ok_or_else(|| RuLakeError::UnknownCollection {
+                backend: self.id.clone(),
+                collection: collection.to_string(),
+            })?;
 
         // Decode the f32 region. `bytemuck::try_cast_slice` returns an
         // error if the slice isn't aligned / sized correctly — we
@@ -302,10 +292,12 @@ impl BackendAdapter for RvdnaT1Backend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.mappings.read().expect("poisoned");
-        let m = g.get(collection).ok_or_else(|| RuLakeError::UnknownCollection {
-            backend: self.id.clone(),
-            collection: collection.to_string(),
-        })?;
+        let m = g
+            .get(collection)
+            .ok_or_else(|| RuLakeError::UnknownCollection {
+                backend: self.id.clone(),
+                collection: collection.to_string(),
+            })?;
         Ok(m.generation)
     }
 }

--- a/crates/rvdna-backend/src/t2.rs
+++ b/crates/rvdna-backend/src/t2.rs
@@ -166,6 +166,7 @@ impl RvdnaT2Backend {
     /// scale files are remote-mounted on FUSE / S3FS in production
     /// and stat'ing them up-front defeats the lazy-tier purpose. The
     /// per-call `seek+read` will surface an error at first access.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_file(
         &self,
         name: impl Into<String>,
@@ -181,7 +182,7 @@ impl RvdnaT2Backend {
                 "rvdna-t2: dim must be > 0".into(),
             ));
         }
-        if vectors_offset % (std::mem::align_of::<f32>() as u64) != 0 {
+        if !vectors_offset.is_multiple_of(std::mem::align_of::<f32>() as u64) {
             return Err(RuLakeError::InvalidParameter(format!(
                 "rvdna-t2: vectors_offset={vectors_offset} not f32-aligned"
             )));
@@ -206,10 +207,7 @@ impl RvdnaT2Backend {
 
         let path_buf = path.as_ref().to_path_buf();
         let file = std::fs::File::open(&path_buf).map_err(|e| {
-            RuLakeError::InvalidParameter(format!(
-                "rvdna-t2: open {}: {e}",
-                path_buf.display()
-            ))
+            RuLakeError::InvalidParameter(format!("rvdna-t2: open {}: {e}", path_buf.display()))
         })?;
 
         let cap = NonZeroUsize::new(DEFAULT_LRU_CAP).expect("DEFAULT_LRU_CAP > 0");
@@ -297,10 +295,12 @@ impl BackendAdapter for RvdnaT2Backend {
 
     fn pull_vectors(&self, collection: &str) -> Result<PulledBatch> {
         let g = self.mappings.read().expect("poisoned");
-        let m = g.get(collection).ok_or_else(|| RuLakeError::UnknownCollection {
-            backend: self.id.clone(),
-            collection: collection.to_string(),
-        })?;
+        let m = g
+            .get(collection)
+            .ok_or_else(|| RuLakeError::UnknownCollection {
+                backend: self.id.clone(),
+                collection: collection.to_string(),
+            })?;
 
         let mut vectors: Vec<Vec<f32>> = Vec::with_capacity(m.n_vectors);
 
@@ -405,10 +405,12 @@ impl BackendAdapter for RvdnaT2Backend {
 
     fn generation(&self, collection: &str) -> Result<u64> {
         let g = self.mappings.read().expect("poisoned");
-        let m = g.get(collection).ok_or_else(|| RuLakeError::UnknownCollection {
-            backend: self.id.clone(),
-            collection: collection.to_string(),
-        })?;
+        let m = g
+            .get(collection)
+            .ok_or_else(|| RuLakeError::UnknownCollection {
+                backend: self.id.clone(),
+                collection: collection.to_string(),
+            })?;
         Ok(m.generation)
     }
 }

--- a/crates/rvdna-backend/tests/smoke.rs
+++ b/crates/rvdna-backend/tests/smoke.rs
@@ -23,8 +23,15 @@ fn fixture_collection(seed: u64, n: usize, dim: usize) -> RvdnaCollection {
         x as f32 / u64::MAX as f32
     };
     let ids: Vec<u64> = (0..n as u64).collect();
-    let vectors: Vec<Vec<f32>> = (0..n).map(|_| (0..dim).map(|_| next() * 2.0 - 1.0).collect()).collect();
-    RvdnaCollection { ids, vectors, dim, generation: 1 }
+    let vectors: Vec<Vec<f32>> = (0..n)
+        .map(|_| (0..dim).map(|_| next() * 2.0 - 1.0).collect())
+        .collect();
+    RvdnaCollection {
+        ids,
+        vectors,
+        dim,
+        generation: 1,
+    }
 }
 
 #[test]
@@ -39,7 +46,10 @@ fn t0_backend_adapter_contract_holds() {
     // list_collections
     let mut cols = be.list_collections().unwrap();
     cols.sort();
-    assert_eq!(cols, vec!["brca1-kmers".to_string(), "hbb-kmers".to_string()]);
+    assert_eq!(
+        cols,
+        vec!["brca1-kmers".to_string(), "hbb-kmers".to_string()]
+    );
 
     // pull_vectors
     let batch = be.pull_vectors("hbb-kmers").unwrap();
@@ -66,12 +76,16 @@ fn t0_backend_round_trips_through_rulake_cache() {
 
     // First search primes from the backend.
     let q = vec![0.0_f32; 16];
-    let hits1 = lake.search_one("rvdna-fixture", "hbb-kmers", &q, 5).unwrap();
+    let hits1 = lake
+        .search_one("rvdna-fixture", "hbb-kmers", &q, 5)
+        .unwrap();
     assert_eq!(hits1.len(), 5, "got {} hits", hits1.len());
 
     // Second search hits the cache (faster, but we just verify it
     // returns the same byte-exact ranking).
-    let hits2 = lake.search_one("rvdna-fixture", "hbb-kmers", &q, 5).unwrap();
+    let hits2 = lake
+        .search_one("rvdna-fixture", "hbb-kmers", &q, 5)
+        .unwrap();
     assert_eq!(hits1, hits2);
 
     let stats = lake.cache_stats();
@@ -95,14 +109,21 @@ fn generation_bump_invalidates_cache() {
     lake.register_backend(be).unwrap();
 
     let q = vec![0.0_f32; 16];
-    let _ = lake.search_one("rvdna-fixture", "hbb-kmers", &q, 3).unwrap();
+    let _ = lake
+        .search_one("rvdna-fixture", "hbb-kmers", &q, 3)
+        .unwrap();
     let primes_before = lake.cache_stats().primes;
 
     // Bump the underlying generation via the concrete handle. Next
     // Fresh search must re-prime.
     let _ = raw.bump_generation("hbb-kmers").unwrap();
 
-    let _ = lake.search_one("rvdna-fixture", "hbb-kmers", &q, 3).unwrap();
+    let _ = lake
+        .search_one("rvdna-fixture", "hbb-kmers", &q, 3)
+        .unwrap();
     let primes_after = lake.cache_stats().primes;
-    assert!(primes_after > primes_before, "Fresh + gen bump must invalidate");
+    assert!(
+        primes_after > primes_before,
+        "Fresh + gen bump must invalidate"
+    );
 }

--- a/crates/rvdna-backend/tests/t1_smoke.rs
+++ b/crates/rvdna-backend/tests/t1_smoke.rs
@@ -62,7 +62,12 @@ fn t0_collection_from(seed: u64, n: usize, dim: usize) -> RvdnaCollection {
     let vectors: Vec<Vec<f32>> = (0..n)
         .map(|i| flat[i * dim..(i + 1) * dim].to_vec())
         .collect();
-    RvdnaCollection { ids, vectors, dim, generation: 1 }
+    RvdnaCollection {
+        ids,
+        vectors,
+        dim,
+        generation: 1,
+    }
 }
 
 #[test]
@@ -79,16 +84,15 @@ fn t1_backend_round_trips_through_rulake_cache() {
             file.path(),
             dim,
             1,
-            0,                // ids_offset (unused — has_ids=false)
+            0, // ids_offset (unused — has_ids=false)
             vectors_offset,
             n,
-            false,            // synthesise positional ids
+            false, // synthesise positional ids
         )
         .expect("register");
     let t1_be: Arc<dyn BackendAdapter> = Arc::clone(&t1_raw) as Arc<dyn BackendAdapter>;
 
-    let t1_lake =
-        RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
+    let t1_lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
     t1_lake.register_backend(t1_be).unwrap();
 
     let q = vec![0.0_f32; dim];
@@ -108,8 +112,7 @@ fn t1_backend_round_trips_through_rulake_cache() {
     let t0 = RvdnaT0Backend::new("rvdna-t0-fixture");
     t0.put_collection("hbb-kmers", t0_collection_from(0xc0ffee, n, dim));
     let t0_be: Arc<dyn BackendAdapter> = Arc::new(t0);
-    let t0_lake =
-        RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
+    let t0_lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
     t0_lake.register_backend(t0_be).unwrap();
     let t0_hits = t0_lake
         .search_one("rvdna-t0-fixture", "hbb-kmers", &q, 5)

--- a/crates/rvdna-backend/tests/t2_smoke.rs
+++ b/crates/rvdna-backend/tests/t2_smoke.rs
@@ -25,9 +25,7 @@ use rulake::backend::BackendAdapter;
 use rulake::cache::Consistency;
 use rulake::RuLake;
 use ruvector_rulake_rvdna::witness::{rvdna_bundle, RvdnaWitnessInputs};
-use ruvector_rulake_rvdna::{
-    RvdnaCollection, RvdnaT0Backend, RvdnaT1Backend, RvdnaT2Backend,
-};
+use ruvector_rulake_rvdna::{RvdnaCollection, RvdnaT0Backend, RvdnaT1Backend, RvdnaT2Backend};
 
 /// Deterministic mulberry32-equivalent — mirrors `tests/smoke.rs` and
 /// `tests/t1_smoke.rs` so T0 / T1 / T2 fixtures with the same
@@ -67,7 +65,12 @@ fn t0_collection_from(seed: u64, n: usize, dim: usize) -> RvdnaCollection {
     let vectors: Vec<Vec<f32>> = (0..n)
         .map(|i| flat[i * dim..(i + 1) * dim].to_vec())
         .collect();
-    RvdnaCollection { ids, vectors, dim, generation: 1 }
+    RvdnaCollection {
+        ids,
+        vectors,
+        dim,
+        generation: 1,
+    }
 }
 
 #[test]
@@ -91,8 +94,7 @@ fn t2_backend_round_trips_through_rulake_cache() {
         .expect("register");
     let t2_be: Arc<dyn BackendAdapter> = Arc::clone(&t2_raw) as Arc<dyn BackendAdapter>;
 
-    let t2_lake =
-        RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
+    let t2_lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
     t2_lake.register_backend(t2_be).unwrap();
 
     let q = vec![0.0_f32; dim];
@@ -112,8 +114,7 @@ fn t2_backend_round_trips_through_rulake_cache() {
     let t0 = RvdnaT0Backend::new("rvdna-t0-fixture");
     t0.put_collection("raw-dna-chr17", t0_collection_from(0xc0ffee, n, dim));
     let t0_be: Arc<dyn BackendAdapter> = Arc::new(t0);
-    let t0_lake =
-        RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
+    let t0_lake = RuLake::new(20, 42).with_consistency(Consistency::Eventual { ttl_ms: 1_000 });
     t0_lake.register_backend(t0_be).unwrap();
     let t0_hits = t0_lake
         .search_one("rvdna-t0-fixture", "raw-dna-chr17", &q, 5)
@@ -213,7 +214,10 @@ fn t2_lru_warms_under_repeated_search() {
         stats_after_1.misses, n as u64,
         "first pull must fault every vector in (disk read)"
     );
-    assert_eq!(stats_after_1.hits, 0, "first pull must not have any LRU hits");
+    assert_eq!(
+        stats_after_1.hits, 0,
+        "first pull must not have any LRU hits"
+    );
     assert_eq!(stats_after_1.len, n, "first pull must populate the LRU");
 
     // Calls 2..10 hit the LRU.
@@ -234,7 +238,13 @@ fn t2_lru_warms_under_repeated_search() {
     // Generation bump invalidates the LRU and the stat counters.
     let _ = raw.bump_generation("raw-dna-chr17").expect("bump");
     let stats_after_bump = raw.lru_stats("raw-dna-chr17").expect("stats");
-    assert_eq!(stats_after_bump.hits, 0, "gen bump must reset LRU hit counter");
-    assert_eq!(stats_after_bump.misses, 0, "gen bump must reset LRU miss counter");
+    assert_eq!(
+        stats_after_bump.hits, 0,
+        "gen bump must reset LRU hit counter"
+    );
+    assert_eq!(
+        stats_after_bump.misses, 0,
+        "gen bump must reset LRU miss counter"
+    );
     assert_eq!(stats_after_bump.len, 0, "gen bump must clear LRU contents");
 }


### PR DESCRIPTION
## Summary

Automated security and correctness audit of all 10 Rust crates. `cargo audit` found no CVEs. Clippy (`-D warnings`) surfaced 30+ issues across 8 crates — all fixed.

### Security fixes

- **`mcp-server/auth`**: `cloned_ref_to_slice_refs` — JWT issuer/audience strings were unnecessarily cloned before being passed to `set_issuer`/`set_audience`. Replaced with `std::slice::from_ref` (avoids heap allocation on every JWT validation call).
- **`ruqu-backend/qec`**: `manual_saturating_arithmetic` — `checked_mul(...).unwrap_or(usize::MAX)` replaced with `saturating_mul` (clearer intent, no panic risk).
- **`mcp-rvdna/server`**: Collapsed identical `if msg.starts_with("RVDNA_INTERNAL") { ... } else { ... }` branches into a single else (dead code that would have silently masked internal error classification).

### Correctness fixes

- **`mcp-server/planner`**: `PlanError::Refused` variant was 384+ bytes. Boxed `QueryResponse` to reduce enum to pointer-sized, fixing `large_enum_variant` and `result_large_err`. All construction and destructuring sites updated.
- **`mcp-server/main`**: `Transport::Http(HttpArgs)` boxed for the same reason (344-byte stack variant next to a zero-byte `Stdio`).
- **`ruqu-backend/state_vector`**: Renamed `add`, `sub`, `mul` methods on complex number type `C` to implement `std::ops::{Add, Sub, Mul}` traits instead. Fixes `should_implement_trait`.
- **`rvdna-backend/t1,t2`**: `% align != 0` alignment checks replaced with `.is_multiple_of()`.
- **`ipfs-backend`**: `filter(..).next_back()` replaced with `rfind()`.
- **`ruqu-backend/limits`**: `assert!()` on constants moved to `const { assert!() }` so violations become compile errors.

### Code quality

- `ConsistencyConfig` Default derived, useless_vec fix, doc continuation warnings, unused import, field_reassign_with_default, bool_assert_comparison fixes, `cargo fmt --all` across all 10 crates.

## Test plan

- [ ] `cargo audit --no-fetch` passes (0 CVEs)
- [ ] `cargo clippy --all-targets -- -D warnings` passes for all 10 crates
- [ ] `cargo fmt --all -- --check` passes for all 10 crates
- [ ] `cargo test --workspace` — 9/10 crates pass; mcp-rvdna has 2 pre-existing failures unrelated to this PR

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)