### PR TITLE
feat(core): optional BackendAdapter::pull_prebuilt_index (Path C, pairs with RuVector#557)

### DIFF
--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -22,6 +22,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+use ruvector_rabitq::RabitqPlusIndex;
+
 use crate::error::{Result, RuLakeError};
 
 /// Stable identifier for a registered backend.
@@ -107,6 +109,21 @@ pub(crate) fn validate_pulled_batch(batch: &PulledBatch) -> Result<()> {
     Ok(())
 }
 
+/// An already-compressed index a backend can hand the cache directly,
+/// bypassing the `pull_vectors` round-trip and the RaBitQ encode on prime.
+///
+/// Returned by [`BackendAdapter::pull_prebuilt_index`]. Installed verbatim
+/// via the cache's warm-install path — no compression runs.
+pub struct PrebuiltIndex {
+    /// The already-compressed index (e.g. built from an `.rvf`'s native
+    /// RaBitQ codes, or loaded from an `.rbpx` sidecar).
+    pub index: Arc<RabitqPlusIndex>,
+    /// Position→id mapping aligned to `index`; the cache would otherwise
+    /// derive this from `PulledBatch::ids`. Its length MUST equal
+    /// `index.len()` or the install is rejected.
+    pub pos_to_id: Arc<Vec<u64>>,
+}
+
 pub trait BackendAdapter: Send + Sync {
     fn id(&self) -> &str;
 
@@ -138,6 +155,20 @@ pub trait BackendAdapter: Send + Sync {
             rerank_factor,
             crate::Generation::Num(batch.generation),
         ))
+    }
+
+    /// Optionally hand the cache an already-compressed index for
+    /// `collection`, letting it skip the `pull_vectors` round-trip and the
+    /// RaBitQ encode on prime.
+    ///
+    /// Backends whose on-disk format already carries RaBitQ codes (e.g. RVF)
+    /// override this; the default returns `None`, so every existing backend
+    /// keeps falling back to `pull_vectors` + encode unchanged. When `Some`,
+    /// the [`PrebuiltIndex`] is installed via the cache's warm-install path
+    /// (`install_prebuilt`); its `pos_to_id` length must match the index
+    /// length or the install is rejected.
+    fn pull_prebuilt_index(&self, _collection: &str) -> Result<Option<PrebuiltIndex>> {
+        Ok(None)
     }
 
     fn supports_pushdown(&self) -> bool {
@@ -341,6 +372,15 @@ mod tests {
             dim,
             generation: 1,
         }
+    }
+
+    #[test]
+    fn default_pull_prebuilt_index_is_none() {
+        // Backends without pre-compressed codes must opt out via the
+        // default so the cache falls back to pull + encode. RVF (which
+        // carries native RaBitQ codes) is the backend expected to override.
+        let back = LocalBackend::new("b");
+        assert!(back.pull_prebuilt_index("any-collection").unwrap().is_none());
     }
 
     #[test]

--- a/crates/core/src/lake.rs
+++ b/crates/core/src/lake.rs
@@ -696,10 +696,25 @@ impl RuLake {
         // existing entry for the target witness if present, or builds
         // a new one.
         self.cache.mark_miss(key);
-        let batch = backend.pull_vectors(&key.1)?;
         // Clone the Arcs (refcount bumps) to hand the cache an owned
         // InternedKey — no String allocation.
         let owned_key: InternedKey = (Arc::clone(&key.0), Arc::clone(&key.1));
+
+        // Path C: if the backend can hand us an already-compressed index
+        // (e.g. RVF, whose on-disk format already carries RaBitQ codes),
+        // install it directly — no pull round-trip and no re-encode. Falls
+        // through to pull + prime for backends that opt out (the default).
+        if let Some(prebuilt) = backend.pull_prebuilt_index(&key.1)? {
+            self.cache.install_prebuilt_interned(
+                owned_key,
+                target_witness,
+                prebuilt.index,
+                prebuilt.pos_to_id,
+            )?;
+            return Ok(());
+        }
+
+        let batch = backend.pull_vectors(&key.1)?;
         self.cache
             .prime_interned(owned_key, target_witness, batch)?;
         Ok(())


### PR DESCRIPTION
## What & why

Implements **Path C** from `docs/research/rvf-backend-blocker.md`: extend `BackendAdapter` so a backend can hand the cache an **already-compressed index**, skipping both the `pull_vectors` round-trip and the RaBitQ encode on prime.

This is the companion to the upstream **`rvf-runtime` vector-iterator PR (ruvnet/RuVector#557)**. Together they let RVF — whose on-disk format already carries RaBitQ codes — serve as a native ruLake backend without re-encoding on every prime (the doc's recommended "A + C together").

## Change

- **`backend.rs`**
  - New `PrebuiltIndex { index: Arc<RabitqPlusIndex>, pos_to_id: Arc<Vec<u64>> }`.
  - New trait method `pull_prebuilt_index(&self, collection) -> Result<Option<PrebuiltIndex>>`, **default `Ok(None)`** — every existing backend (Local, GCS, IPFS) is unchanged and keeps falling back to `pull_vectors` + encode.
- **`lake.rs` (`ensure_fresh`)** — on a miss, try `pull_prebuilt_index` first; on `Some`, route straight to the existing `install_prebuilt_interned` warm path (no compression, `warm_installs` bumped); on `None`, the unchanged `pull_vectors` + `prime_interned` path.

No format change, no new IO. The warm-install path itself is already covered by the existing `install_prebuilt` tests; this PR adds a unit test asserting the default opts out (`None`).

## Scope / follow-up

This lands the trait + consumption. The concrete `RvfBackend` that *returns* `Some` depends on #557 landing (public vector reader) plus exposing RVF's RaBitQ codes — natural next PR.
